### PR TITLE
RESThub HTTP Client refactoring

### DIFF
--- a/resthub-web/resthub-web-client/src/main/java/org/resthub/web/Client.java
+++ b/resthub-web/resthub-web-client/src/main/java/org/resthub/web/Client.java
@@ -1,112 +1,149 @@
 package org.resthub.web;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.ning.http.client.AsyncHttpClientConfig.Builder;
+import com.ning.http.client.Realm.AuthScheme;
+import com.ning.http.client.Realm.RealmBuilder;
+import com.ning.http.client.*;
+import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.concurrent.Future;
-
 import org.resthub.web.oauth2.OAuth2RequestFilter;
-
-import com.ning.http.client.AsyncCompletionHandler;
-import com.ning.http.client.AsyncHttpClient;
-import com.ning.http.client.AsyncHttpClientConfig.Builder;
-import com.ning.http.client.FluentStringsMap;
-import com.ning.http.client.Realm;
-import com.ning.http.client.Realm.AuthScheme;
-import com.ning.http.client.Realm.RealmBuilder;
-import com.ning.http.client.RequestBuilderBase;
 
 /**
  * RESThub AsyncHttpClient wrapper inspired from Play Framework 2 one
- * 
- * Sample usage : User user = Client.url("http://localhost:8080/api/user".jsonPost(user).get().jsonDeserialize(User.class);
  *
- **/
-public class Client {
+ * Sample usage : User user =
+ * Client.url("http://localhost:8080/api/user".jsonPost(user).get().jsonDeserialize(User.class);
+ *
+ *
+ */
+public class Client implements Closeable {
+
+    protected AsyncHttpClient client;
+    protected Builder builder;
+    private String username = null;
+    private String password = null;
+    private String clientId = null;
+    private String clientSecret = null;
+    private String accessTokenEndpoint = null;
+    private AuthScheme scheme = null;
+
+    public Client() {
+        this.builder = new Builder();
+    }
+
+    public Client(Builder builder) {
+        this.builder = builder;
+    }
+
+    public Client setProxy(String host, int port) {
+        this.builder.setProxyServer(new ProxyServer(host, port));
+        return this;
+    }
+
+    /**
+     * Sets the authentication header for the current request.
+     *
+     * @param username
+     * @param password
+     * @param scheme authentication scheme
+     */
+    public Client setAuth(String username, String password, AuthScheme scheme) {
+        this.username = username;
+        this.password = password;
+        this.scheme = scheme;
+        return this;
+    }
+
+    /**
+     * Sets the OAuth2 authentication header for the current request.
+     *
+     * @param username
+     * @param password
+     * @param accessTokenEndpoint
+     * @param clientId
+     * @param clientSecret
+     */
+    public Client setOAuth2(String username, String password, String accessTokenEndpoint, String clientId, String clientSecret) {
+        this.username = username;
+        this.password = password;
+        this.accessTokenEndpoint = accessTokenEndpoint;
+        this.clientId = clientId;
+        this.clientSecret = clientSecret;
+        builder.addRequestFilter(new OAuth2RequestFilter(accessTokenEndpoint, clientId, clientSecret));
+        return this;
+    }
 
     /**
      * Prepare a new request. You can then construct it by chaining calls.
      *
      * @param url the URL to request
      */
-    public static RequestHolder url(String url) {
+    public RequestHolder url(String url) {
+        if (this.client == null) {
+            this.client = new AsyncHttpClient(builder.build());
+        }
         return new RequestHolder(url);
+    }
+
+    @Override
+    public void close() {
+        if (client != null) {
+            client.close();
+        }
     }
 
     /**
      * Provides the bridge between the wrapper and the underlying ning request
      */
-    public static class Request extends RequestBuilderBase<Request> {
+    public class Request extends RequestBuilderBase<Request> {
 
-        private Builder builder = new Builder();
-        
         public Request(String method) {
             super(Request.class, method, false);
         }
 
         private Request auth(String username, String password, AuthScheme scheme) {
-            this.setRealm((new RealmBuilder())
-                .setScheme(scheme)
-                .setPrincipal(username)
-                .setPassword(password)
-                .setUsePreemptiveAuth(true)
-                .build());
+            this.setRealm((new RealmBuilder()).setScheme(scheme).setPrincipal(username).setPassword(password).setUsePreemptiveAuth(true).build());
             return this;
-        }
-        
-        public void setBuilder(Builder builder) {
-            this.builder = builder;
-        }
-        
-         public Builder getBuilder() {
-            return this.builder;
         }
 
         private Future<Response> execute() {
             Future<Response> future = null;
             try {
-                future = new AsyncHttpClient(builder.build()).executeRequest(request, new AsyncCompletionHandler<Response>() {
-                @Override
-                public Response onCompleted(com.ning.http.client.Response response) {
-                    return new Response(response);
-                }
-            });
+                future = client.executeRequest(request, new AsyncCompletionHandler<Response>() {
+
+                    @Override
+                    public Response onCompleted(com.ning.http.client.Response response) {
+                        return new Response(response);
+                    }
+                });
             } catch (IOException ex) {
                 future.cancel(true);
             }
             return future;
         }
     }
-    
+
     /**
      * provides the User facing API for building WS request.
      */
-    public static class RequestHolder {
+    public class RequestHolder {
 
         private final String url;
-        private Map<String, Collection<String>> headers = new HashMap<String, Collection<String>>();
-        private Map<String, Collection<String>> queryParameters = new HashMap<String, Collection<String>>();
-
+        private Map<String, Collection<String>> headers = new HashMap<>();
+        private Map<String, Collection<String>> queryParameters = new HashMap<>();
         private String body = null;
-        private String username = null;
-        private String password = null;
-        private String clientId = null;
-        private String clientSecret = null;
-        private String accessTokenEndpoint = null;
-        private AuthScheme scheme = null;
-        private Builder builder = new Builder();
 
         public RequestHolder(String url) {
             this.url = url;
         }
 
         /**
-         * Sets a header with the given name, this can be called repeatedly 
+         * Sets a header with the given name, this can be called repeatedly
          *
          * @param name
          * @param value
@@ -116,7 +153,7 @@ public class Client {
                 Collection<String> values = headers.get(name);
                 values.add(value);
             } else {
-                List<String> values = new ArrayList<String>();
+                List<String> values = new ArrayList<>();
                 values.add(value);
                 headers.put(name, values);
             }
@@ -124,7 +161,8 @@ public class Client {
         }
 
         /**
-         * Sets a query parameter with the given name,this can be called repeatedly
+         * Sets a query parameter with the given name,this can be called
+         * repeatedly
          *
          * @param name
          * @param value
@@ -134,43 +172,10 @@ public class Client {
                 Collection<String> values = headers.get(name);
                 values.add(value);
             } else {
-                List<String> values = new ArrayList<String>();
+                List<String> values = new ArrayList<>();
                 values.add(value);
                 queryParameters.put(name, values);
             }
-            return this;
-        }
-
-        /**
-         * Sets the authentication header for the current request.
-         *
-         * @param username
-         * @param password
-         * @param scheme authentication scheme
-         */
-        public RequestHolder setAuth(String username, String password, AuthScheme scheme) {
-            this.username = username;
-            this.password = password;
-            this.scheme = scheme;
-            return this;
-        }
-        
-        /**
-         * Sets the OAuth2 authentication header for the current request.
-         *
-         * @param username
-         * @param password
-         * @param accessTokenEndpoint
-         * @param clientId
-         * @param clientSecret
-         */
-        public RequestHolder setOAuth2(String username, String password, String accessTokenEndpoint, String clientId, String clientSecret) {
-            this.username = username;
-            this.password = password;
-            this.accessTokenEndpoint = accessTokenEndpoint;
-            this.clientId = clientId;
-            this.clientSecret = clientSecret;
-            builder.addRequestFilter(new OAuth2RequestFilter(accessTokenEndpoint, clientId, clientSecret));
             return this;
         }
 
@@ -185,7 +190,7 @@ public class Client {
             this.setHeader(Http.ACCEPT, Http.JSON);
             return execute("GET");
         }
-        
+
         public Future<Response> getXml() {
             this.setHeader(Http.ACCEPT, Http.XML);
             return execute("GET");
@@ -199,7 +204,7 @@ public class Client {
         public Future<Response> post(String body) {
             return executeString("POST", body);
         }
-        
+
         public Future<Response> post() {
             return executeString("POST", this.body);
         }
@@ -212,19 +217,18 @@ public class Client {
         public Future<Response> put(String body) {
             return executeString("PUT", body);
         }
-        
+
         public Future<Response> jsonPut(Object o) {
             this.setHeader(Http.ACCEPT, Http.JSON);
             this.setHeader(Http.CONTENT_TYPE, Http.JSON);
             return executeString("PUT", JsonHelper.serialize(o));
         }
-        
+
         public Future<Response> xmlPut(Object o) {
             this.setHeader(Http.ACCEPT, Http.XML);
             this.setHeader(Http.CONTENT_TYPE, Http.XML);
             return executeString("PUT", XmlHelper.serialize(o));
         }
-
 
         /**
          * Perform a POST on the request asynchronously.
@@ -234,13 +238,13 @@ public class Client {
         public Future<Response> post(InputStream body) {
             return executeIS("POST", body);
         }
-        
+
         public Future<Response> jsonPost(Object o) {
             this.setHeader(Http.ACCEPT, Http.JSON);
             this.setHeader(Http.CONTENT_TYPE, Http.JSON);
             return executeString("POST", JsonHelper.serialize(o));
         }
-        
+
         public Future<Response> xmlPost(Object o) {
             this.setHeader(Http.ACCEPT, Http.XML);
             this.setHeader(Http.CONTENT_TYPE, Http.XML);
@@ -280,7 +284,7 @@ public class Client {
         public Future<Response> delete() {
             return execute("DELETE");
         }
-                
+
         /**
          * Perform a HEAD on the request asynchronously.
          */
@@ -297,48 +301,40 @@ public class Client {
 
         private Future<Response> execute(String method) {
             Request req = new Request(method).setUrl(url).setHeaders(headers).setQueryParameters(new FluentStringsMap(queryParameters));
-            if (this.username != null && this.password != null && this.scheme != null)
-                req.auth(this.username, this.password, this.scheme);
-            if(this.accessTokenEndpoint != null && this.clientId != null && this.clientSecret != null && this.username != null && this.password != null) {
-                req.setBuilder(this.builder);
-                req.setRealm(new Realm.RealmBuilder().setPrincipal(this.username).setPassword(this.password).build());
+            if (username != null && password != null && scheme != null) {
+                req.auth(username, password, scheme);
+            }
+            if (accessTokenEndpoint != null && clientId != null && clientSecret != null && username != null && password != null) {
+                req.setRealm(new Realm.RealmBuilder().setPrincipal(username).setPassword(password).build());
             }
             return req.execute();
         }
 
         private Future<Response> executeString(String method, String body) {
-            Request req = new Request(method).setBody(body)
-                                                 .setUrl(url)
-                                                 .setHeaders(headers)
-                                                 .setQueryParameters(new FluentStringsMap(queryParameters));
-            if (this.username != null && this.password != null && this.scheme != null)
-                req.auth(this.username, this.password, this.scheme);
+            Request req = new Request(method).setBody(body).setUrl(url).setHeaders(headers).setQueryParameters(new FluentStringsMap(queryParameters));
+            if (username != null && password != null && scheme != null) {
+                req.auth(username, password, scheme);
+            }
             return req.execute();
         }
 
         private Future<Response> executeIS(String method, InputStream body) {
-            Request req = new Request(method).setBody(body)
-                                                 .setUrl(url)
-                                                 .setHeaders(headers)
-                                                 .setQueryParameters(new FluentStringsMap(queryParameters));
-            if (this.username != null && this.password != null && this.scheme != null)
-                req.auth(this.username, this.password, this.scheme);
+            Request req = new Request(method).setBody(body).setUrl(url).setHeaders(headers).setQueryParameters(new FluentStringsMap(queryParameters));
+            if (username != null && password != null && scheme != null) {
+                req.auth(username, password, scheme);
+            }
             return req.execute();
         }
 
         private Future<Response> executeFile(String method, File body) {
-            Request req = new Request(method).setBody(body)
-                                                 .setUrl(url)
-                                                 .setHeaders(headers)
-                                                 .setQueryParameters(new FluentStringsMap(queryParameters));
-            if (this.username != null && this.password != null && this.scheme != null)
-                req.auth(this.username, this.password, this.scheme);
+            Request req = new Request(method).setBody(body).setUrl(url).setHeaders(headers).setQueryParameters(new FluentStringsMap(queryParameters));
+            if (username != null && password != null && scheme != null) {
+                req.auth(username, password, scheme);
+            }
             return req.execute();
         }
-
-
     }
-    
+
     /**
      * A WS response.
      */
@@ -385,6 +381,17 @@ public class Client {
                 throw new RuntimeException(e);
             }
         }
+        
+        /**
+         * Deserialize a JSON response with Generic type
+         */
+        public <T> T jsonDeserialize(TypeReference valueTypeRef) {
+            try {
+                return (T) JsonHelper.deserialize(ahcResponse.getResponseBody(), valueTypeRef);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
 
         /**
          * Deserialize a XML response
@@ -395,8 +402,17 @@ public class Client {
             } catch (Exception e) {
                 throw new RuntimeException(e);
             }
-        }       
-
+        }
+        
+        /**
+         * Deserialize a XML response with Generic type
+         */
+        public <T> T xmlDeserialize(TypeReference valueTypeRef) {
+            try {
+                return XmlHelper.deserialize(ahcResponse.getResponseBody(), valueTypeRef);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }        
     }
-
 }

--- a/resthub-web/resthub-web-client/src/test/java/org/resthub/web/oauth2/TestOAuth2Client.java
+++ b/resthub-web/resthub-web-client/src/test/java/org/resthub/web/oauth2/TestOAuth2Client.java
@@ -88,14 +88,14 @@ public class TestOAuth2Client {
 
     @Test
     public void testOAuth2SuccessfulRequest() throws IOException, InterruptedException, ExecutionException {
-    	   	
-        String result = Client.url(BASE_URL + "/api/resource/hello").setOAuth2("test", "t3st", ACCESS_TOKEN_ENDPOINT, CLIENT_ID, CLIENT_SECRET).get().get().getBody();
+    	Client client = new Client().setOAuth2("test", "t3st", ACCESS_TOKEN_ENDPOINT, CLIENT_ID, CLIENT_SECRET);   	
+        String result = client.url(BASE_URL + "/api/resource/hello").get().get().getBody();
         Assertions.assertThat(result).isEqualTo("Hello");
     }
 
     @Test
     public void testUnauthorizeRequest() throws IOException, InterruptedException, ExecutionException {
-    	Response response = Client.url(BASE_URL + "/api/resource/hello").getJson().get();
+    	Response response = new Client().url(BASE_URL + "/api/resource/hello").getJson().get();
     	Assertions.assertThat(response.getStatus()).isEqualTo(Http.UNAUTHORIZED);
     }
 

--- a/resthub-web/resthub-web-common/src/main/java/org/resthub/web/JsonHelper.java
+++ b/resthub-web/resthub-web-common/src/main/java/org/resthub/web/JsonHelper.java
@@ -1,5 +1,6 @@
 package org.resthub.web;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import java.io.ByteArrayOutputStream;
 import java.io.OutputStream;
 
@@ -64,7 +65,22 @@ public class JsonHelper {
     public static <T> T deserialize(String content, Class<T> type) {
         if(objectMapper == null) initialize();
         try {
-            return type.cast(objectMapper.readValue(content, type));
+            return objectMapper.readValue(content, type);
+        } catch (Exception e) {
+            throw new SerializationException(e);
+        }
+    }
+    
+    /**
+     * Deserialize a JSON string
+     * @param content The JSON String object representation
+     * @param valueTypeRef The typeReference containing the type of the deserialized object instance
+     * @return The deserialized object instance
+     */
+    public static <T> T deserialize(String content, TypeReference valueTypeRef) {
+        if(objectMapper == null) initialize();
+        try {
+            return objectMapper.readValue(content, valueTypeRef);
         } catch (Exception e) {
             throw new SerializationException(e);
         }

--- a/resthub-web/resthub-web-common/src/main/java/org/resthub/web/XmlHelper.java
+++ b/resthub-web/resthub-web-common/src/main/java/org/resthub/web/XmlHelper.java
@@ -1,5 +1,6 @@
 package org.resthub.web;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import java.io.ByteArrayOutputStream;
 import java.io.OutputStream;
 
@@ -60,10 +61,25 @@ public class XmlHelper {
     public static <T> T deserialize(String content, Class<T> type) {
         if(objectMapper == null) initialize();
         try {
-            return type.cast(objectMapper.readValue(content, type));
+            return objectMapper.readValue(content, type);
         } catch (Exception e) {
             throw new SerializationException(e);
         }
     }  
+    
+    /**
+     * Deserialize a XML string
+     * @param content The JSON String object representation
+     * @param valueTypeRef The typeReference containing the type of the deserialized object instance
+     * @return The deserialized object instance
+     */
+    public static <T> T deserialize(String content, TypeReference valueTypeRef) {
+        if(objectMapper == null) initialize();
+        try {
+            return objectMapper.readValue(content, valueTypeRef);
+        } catch (Exception e) {
+            throw new SerializationException(e);
+        }
+    }
 
 }

--- a/resthub-web/resthub-web-server/src/test/java/org/resthub/web/controller/JsonRepositoryBasedRestControllerTest.java
+++ b/resthub-web/resthub-web-server/src/test/java/org/resthub/web/controller/JsonRepositoryBasedRestControllerTest.java
@@ -5,7 +5,6 @@ import java.util.concurrent.ExecutionException;
 import org.fest.assertions.api.Assertions;
 import org.resthub.test.common.AbstractWebTest;
 import org.resthub.web.Client;
-import org.resthub.web.Client.Response;
 import org.resthub.web.Http;
 import org.resthub.web.model.Sample;
 import org.testng.annotations.AfterMethod;
@@ -20,7 +19,7 @@ public class JsonRepositoryBasedRestControllerTest extends AbstractWebTest {
     @AfterMethod
     public void tearDown() {
     	try {
-            Client.url(rootUrl()).delete().get();
+            new Client().url(rootUrl()).delete().get();
         } catch (InterruptedException | ExecutionException e) {
             Assertions.fail("Exception during delete all request", e);
         }
@@ -29,7 +28,7 @@ public class JsonRepositoryBasedRestControllerTest extends AbstractWebTest {
     @Test
     public void testCreateResource() throws IllegalArgumentException, InterruptedException, ExecutionException, IOException {
         Sample r = new Sample("toto");
-        Response response = Client.url(rootUrl()).jsonPost(r).get();
+        Client.Response response = new Client().url(rootUrl()).jsonPost(r).get();
         r = (Sample)response.jsonDeserialize(r.getClass());
         Assertions.assertThat(r).isNotNull();
         Assertions.assertThat(r.getName()).isEqualTo("toto");
@@ -37,49 +36,54 @@ public class JsonRepositoryBasedRestControllerTest extends AbstractWebTest {
     
     @Test
     public void testFindAllResources() throws IllegalArgumentException, InterruptedException, ExecutionException, IOException {
-    	Client.url(rootUrl()).jsonPost(new Sample("toto")). get();
-        Client.url(rootUrl()).jsonPost(new Sample("toto")).get();
-    	String responseBody = Client.url(rootUrl()).getJson().get().getBody();
+    	Client httpClient = new Client();
+        httpClient.url(rootUrl()).jsonPost(new Sample("toto")). get();
+        httpClient.url(rootUrl()).jsonPost(new Sample("toto")).get();
+    	String responseBody = httpClient.url(rootUrl()).getJson().get().getBody();
         Assertions.assertThat(responseBody).contains("toto");
     }
     
     @Test
     public void testPagingFindAllResources() throws IllegalArgumentException, InterruptedException, ExecutionException, IOException {
-    	Client.url(rootUrl()).jsonPost(new Sample("toto")). get();
-        Client.url(rootUrl()).jsonPost(new Sample("toto")).get();
-    	String responseBody = Client.url(rootUrl() + "/page/0").getJson().get().getBody();
+        Client httpClient = new Client();
+    	httpClient.url(rootUrl()).jsonPost(new Sample("toto")). get();
+        httpClient.url(rootUrl()).jsonPost(new Sample("toto")).get();
+    	String responseBody = httpClient.url(rootUrl() + "/page/0").getJson().get().getBody();
         Assertions.assertThat(responseBody).contains("\"totalElements\":2");
     }
 
     @Test
     public void testDeleteResource() throws IllegalArgumentException, IOException, InterruptedException, ExecutionException {
+        Client httpClient = new Client();
     	Sample r = new Sample("toto");
-        r = (Sample)Client.url(rootUrl()).jsonPost(r).get().jsonDeserialize(r.getClass());
+        r = httpClient.url(rootUrl()).jsonPost(r).get().jsonDeserialize(r.getClass());
         Assertions.assertThat(r).isNotNull();
 
-        Client.Response response = Client.url(rootUrl() + "/" + r.getId()).delete().get();
+        Client.Response response = httpClient.url(rootUrl() + "/" + r.getId()).delete().get();
         Assertions.assertThat(response.getStatus()).isEqualTo(Http.NO_CONTENT);
         
-        response = Client.url(rootUrl() + "/" + r.getId()).get().get();
+        response = httpClient.url(rootUrl() + "/" + r.getId()).get().get();
         Assertions.assertThat(response.getStatus()).isEqualTo(Http.NOT_FOUND);
     }
 
     @Test
     public void testFindResource() throws IllegalArgumentException, IOException, InterruptedException, ExecutionException {
+        Client httpClient = new Client();
         Sample r = new Sample("toto");
-        r = (Sample)Client.url(rootUrl()).jsonPost(r).get().jsonDeserialize(r.getClass());
+        r = httpClient.url(rootUrl()).jsonPost(r).get().jsonDeserialize(r.getClass());
         
-        Client.Response response = Client.url(rootUrl() + "/" + r.getId()).get().get();
+        Client.Response response = httpClient.url(rootUrl() + "/" + r.getId()).get().get();
         Assertions.assertThat(response.getStatus()).isEqualTo(Http.OK);
     }
 
     @Test
     public void testUpdate() throws IllegalArgumentException, IOException, InterruptedException, ExecutionException {
+        Client httpClient = new Client();
         Sample r1 = new Sample("toto");
-        r1 = Client.url(rootUrl()).jsonPost(r1).get().jsonDeserialize(r1.getClass());
+        r1 = httpClient.url(rootUrl()).jsonPost(r1).get().jsonDeserialize(r1.getClass());
         Sample r2 = new Sample(r1);
         r2.setName("titi");
-        r2 = Client.url(rootUrl() + "/" + r1.getId()).jsonPut(r2).get().jsonDeserialize(r2.getClass());
+        r2 = httpClient.url(rootUrl() + "/" + r1.getId()).jsonPut(r2).get().jsonDeserialize(r2.getClass());
         Assertions.assertThat(r1).isNotEqualTo(r2);
         Assertions.assertThat(r1.getName()).contains("toto");
         Assertions.assertThat(r2.getName()).contains("titi");

--- a/resthub-web/resthub-web-server/src/test/java/org/resthub/web/controller/JsonServiceBasedRestControllerTest.java
+++ b/resthub-web/resthub-web-server/src/test/java/org/resthub/web/controller/JsonServiceBasedRestControllerTest.java
@@ -19,7 +19,7 @@ public class JsonServiceBasedRestControllerTest extends AbstractWebTest {
     @AfterMethod
     public void tearDown() {
     	try {
-            Client.url(rootUrl()).delete().get();
+            new Client().url(rootUrl()).delete().get();
         } catch (InterruptedException | ExecutionException e) {
             Assertions.fail("Exception during delete all request", e);
         }
@@ -27,8 +27,9 @@ public class JsonServiceBasedRestControllerTest extends AbstractWebTest {
 
     @Test
     public void testCreateResource() throws IllegalArgumentException, InterruptedException, ExecutionException, IOException {
+        Client httpClient = new Client();
         Sample r = new Sample("toto");
-        Client.Response response = Client.url(rootUrl()).jsonPost(r).get();
+        Client.Response response = httpClient.url(rootUrl()).jsonPost(r).get();
         r = (Sample)response.jsonDeserialize(r.getClass());
         Assertions.assertThat(r).isNotNull();
         Assertions.assertThat(r.getName()).isEqualTo("toto");
@@ -36,49 +37,54 @@ public class JsonServiceBasedRestControllerTest extends AbstractWebTest {
     
     @Test
     public void testFindAllResources() throws IllegalArgumentException, InterruptedException, ExecutionException, IOException {
-    	Client.url(rootUrl()).jsonPost(new Sample("toto")). get();
-        Client.url(rootUrl()).jsonPost(new Sample("toto")).get();
-    	String responseBody = Client.url(rootUrl()).getJson().get().getBody();
+        Client httpClient = new Client();
+    	httpClient.url(rootUrl()).jsonPost(new Sample("toto")). get();
+        httpClient.url(rootUrl()).jsonPost(new Sample("toto")).get();
+    	String responseBody = httpClient.url(rootUrl()).getJson().get().getBody();
         Assertions.assertThat(responseBody).contains("toto");
     }
     
     @Test
     public void testPagingFindAllResources() throws IllegalArgumentException, InterruptedException, ExecutionException, IOException {
-    	Client.url(rootUrl()).jsonPost(new Sample("toto")). get();
-        Client.url(rootUrl()).jsonPost(new Sample("toto")).get();
-    	String responseBody = Client.url(rootUrl() + "/page/0").getJson().get().getBody();
+        Client httpClient = new Client();
+    	httpClient.url(rootUrl()).jsonPost(new Sample("toto")). get();
+        httpClient.url(rootUrl()).jsonPost(new Sample("toto")).get();
+    	String responseBody = httpClient.url(rootUrl() + "/page/0").getJson().get().getBody();
         Assertions.assertThat(responseBody).contains("\"totalElements\":2");
     }
 
     @Test
     public void testDeleteResource() throws IllegalArgumentException, IOException, InterruptedException, ExecutionException {
+        Client httpClient = new Client();
     	Sample r = new Sample("toto");
-        r = (Sample)Client.url(rootUrl()).jsonPost(r).get().jsonDeserialize(r.getClass());
+        r = httpClient.url(rootUrl()).jsonPost(r).get().jsonDeserialize(r.getClass());
         Assertions.assertThat(r).isNotNull();
 
-        Client.Response response = Client.url(rootUrl() + "/" + r.getId()).delete().get();
+        Client.Response response = httpClient.url(rootUrl() + "/" + r.getId()).delete().get();
         Assertions.assertThat(response.getStatus()).isEqualTo(Http.NO_CONTENT);
         
-        response = Client.url(rootUrl() + "/" + r.getId()).get().get();
+        response = httpClient.url(rootUrl() + "/" + r.getId()).get().get();
         Assertions.assertThat(response.getStatus()).isEqualTo(Http.NOT_FOUND);
     }
 
     @Test
     public void testFindResource() throws IllegalArgumentException, IOException, InterruptedException, ExecutionException {
+        Client httpClient = new Client();
         Sample r = new Sample("toto");
-        r = (Sample)Client.url(rootUrl()).jsonPost(r).get().jsonDeserialize(r.getClass());
+        r = httpClient.url(rootUrl()).jsonPost(r).get().jsonDeserialize(r.getClass());
         
-        Client.Response response = Client.url(rootUrl() + "/" + r.getId()).get().get();
+        Client.Response response = httpClient.url(rootUrl() + "/" + r.getId()).get().get();
         Assertions.assertThat(response.getStatus()).isEqualTo(Http.OK);
     }
 
     @Test
     public void testUpdate() throws IllegalArgumentException, IOException, InterruptedException, ExecutionException {
+        Client httpClient = new Client();
         Sample r1 = new Sample("toto");
-        r1 = Client.url(rootUrl()).jsonPost(r1).get().jsonDeserialize(r1.getClass());
+        r1 = httpClient.url(rootUrl()).jsonPost(r1).get().jsonDeserialize(r1.getClass());
         Sample r2 = new Sample(r1);
         r2.setName("titi");
-        r2 = Client.url(rootUrl() + "/" + r1.getId()).jsonPut(r2).get().jsonDeserialize(r2.getClass());
+        r2 = httpClient.url(rootUrl() + "/" + r1.getId()).jsonPut(r2).get().jsonDeserialize(r2.getClass());
         Assertions.assertThat(r1).isNotEqualTo(r2);
         Assertions.assertThat(r1.getName()).contains("toto");
         Assertions.assertThat(r2.getName()).contains("titi");

--- a/resthub-web/resthub-web-server/src/test/java/org/resthub/web/controller/XmlRepositoryBasedRestControllerWebTest.java
+++ b/resthub-web/resthub-web-server/src/test/java/org/resthub/web/controller/XmlRepositoryBasedRestControllerWebTest.java
@@ -19,7 +19,7 @@ public class XmlRepositoryBasedRestControllerWebTest extends AbstractWebTest {
     @AfterMethod
     public void tearDown() {
     	try {
-            Client.url(rootUrl()).delete().get();
+            new Client().url(rootUrl()).delete().get();
         } catch (InterruptedException | ExecutionException e) {
             Assertions.fail("Exception during delete all request", e);
         }
@@ -27,8 +27,9 @@ public class XmlRepositoryBasedRestControllerWebTest extends AbstractWebTest {
 
     @Test
     public void testCreateResource() throws IllegalArgumentException, InterruptedException, ExecutionException, IOException {
+        Client httpClient = new Client();
         Sample r = new Sample("toto");
-        Client.Response response = Client.url(rootUrl()).xmlPost(r).get();
+        Client.Response response = httpClient.url(rootUrl()).xmlPost(r).get();
         r = (Sample)response.xmlDeserialize(r.getClass());
         Assertions.assertThat(r).isNotNull();
         Assertions.assertThat(r.getName()).isEqualTo("toto");
@@ -36,49 +37,54 @@ public class XmlRepositoryBasedRestControllerWebTest extends AbstractWebTest {
 
     @Test
     public void testFindAllResources() throws IllegalArgumentException, InterruptedException, ExecutionException, IOException {
-    	Client.url(rootUrl()).xmlPost(new Sample("toto")). get();
-        Client.url(rootUrl()).xmlPost(new Sample("toto")).get();
-    	String responseBody = Client.url(rootUrl()).getXml().get().getBody();
+        Client httpClient = new Client();
+    	httpClient.url(rootUrl()).xmlPost(new Sample("toto")). get();
+        httpClient.url(rootUrl()).xmlPost(new Sample("toto")).get();
+    	String responseBody = httpClient.url(rootUrl()).getXml().get().getBody();
         Assertions.assertThat(responseBody).contains("toto");
     }
     
     @Test
     public void testPagingFindAllResources() throws IllegalArgumentException, InterruptedException, ExecutionException, IOException {
-    	Client.url(rootUrl()).xmlPost(new Sample("toto")). get();
-        Client.url(rootUrl()).xmlPost(new Sample("toto")).get();
-    	String responseBody = Client.url(rootUrl() + "/page/0").getXml().get().getBody();
+        Client httpClient = new Client();
+    	httpClient.url(rootUrl()).xmlPost(new Sample("toto")). get();
+        httpClient.url(rootUrl()).xmlPost(new Sample("toto")).get();
+    	String responseBody = httpClient.url(rootUrl() + "/page/0").getXml().get().getBody();
         Assertions.assertThat(responseBody).contains("<totalElements>2</totalElements>");
     }
 
     @Test
     public void testDeleteResource() throws IllegalArgumentException, IOException, InterruptedException, ExecutionException {
+        Client httpClient = new Client();
     	Sample r = new Sample("toto");
-        r = (Sample)Client.url(rootUrl()).xmlPost(r).get().xmlDeserialize(r.getClass());
+        r = (Sample)httpClient.url(rootUrl()).xmlPost(r).get().xmlDeserialize(r.getClass());
         Assertions.assertThat(r).isNotNull();
 
-        Client.Response response = Client.url(rootUrl() + "/" + r.getId()).delete().get();
+        Client.Response response = httpClient.url(rootUrl() + "/" + r.getId()).delete().get();
         Assertions.assertThat(response.getStatus()).isEqualTo(Http.NO_CONTENT);
         
-        response = Client.url(rootUrl() + "/" + r.getId()).get().get();
+        response = httpClient.url(rootUrl() + "/" + r.getId()).get().get();
         Assertions.assertThat(response.getStatus()).isEqualTo(Http.NOT_FOUND);
     }
 
     @Test
     public void testFindResource() throws IllegalArgumentException, IOException, InterruptedException, ExecutionException {
+        Client httpClient = new Client();
         Sample r = new Sample("toto");
-        r = (Sample)Client.url(rootUrl()).xmlPost(r).get().xmlDeserialize(r.getClass());
+        r = (Sample)httpClient.url(rootUrl()).xmlPost(r).get().xmlDeserialize(r.getClass());
         
-        Client.Response response = Client.url(rootUrl() + "/" + r.getId()).get().get();
+        Client.Response response = httpClient.url(rootUrl() + "/" + r.getId()).get().get();
         Assertions.assertThat(response.getStatus()).isEqualTo(Http.OK);
     }
 
     @Test
     public void testUpdate() throws IllegalArgumentException, IOException, InterruptedException, ExecutionException {
+        Client httpClient = new Client();
         Sample r1 = new Sample("toto");
-        r1 = Client.url(rootUrl()).xmlPost(r1).get().xmlDeserialize(r1.getClass());
+        r1 = httpClient.url(rootUrl()).xmlPost(r1).get().xmlDeserialize(r1.getClass());
         Sample r2 = new Sample(r1);
         r2.setName("titi");
-        r2 = Client.url(rootUrl() + "/" + r1.getId()).xmlPut(r2).get().xmlDeserialize(r2.getClass());
+        r2 = httpClient.url(rootUrl() + "/" + r1.getId()).xmlPut(r2).get().xmlDeserialize(r2.getClass());
         Assertions.assertThat(r1).isNotEqualTo(r2);
         Assertions.assertThat(r1.getName()).contains("toto");
         Assertions.assertThat(r2.getName()).contains("titi");

--- a/resthub-web/resthub-web-server/src/test/java/org/resthub/web/controller/XmlServiceBasedRestControllerWebTest.java
+++ b/resthub-web/resthub-web-server/src/test/java/org/resthub/web/controller/XmlServiceBasedRestControllerWebTest.java
@@ -19,7 +19,7 @@ public class XmlServiceBasedRestControllerWebTest extends AbstractWebTest {
     @AfterMethod
     public void tearDown() {
     	try {
-            Client.url(rootUrl()).delete().get();
+            new Client().url(rootUrl()).delete().get();
         } catch (InterruptedException | ExecutionException e) {
             Assertions.fail("Exception during delete all request", e);
         }
@@ -27,8 +27,9 @@ public class XmlServiceBasedRestControllerWebTest extends AbstractWebTest {
 
     @Test
     public void testCreateResource() throws IllegalArgumentException, InterruptedException, ExecutionException, IOException {
+        Client httpClient = new Client();
         Sample r = new Sample("toto");
-        Client.Response response = Client.url(rootUrl()).xmlPost(r).get();
+        Client.Response response = httpClient.url(rootUrl()).xmlPost(r).get();
         r = (Sample)response.xmlDeserialize(r.getClass());
         Assertions.assertThat(r).isNotNull();
         Assertions.assertThat(r.getName()).isEqualTo("toto");
@@ -36,49 +37,54 @@ public class XmlServiceBasedRestControllerWebTest extends AbstractWebTest {
 
     @Test
     public void testFindAllResources() throws IllegalArgumentException, InterruptedException, ExecutionException, IOException {
-    	Client.url(rootUrl()).xmlPost(new Sample("toto")). get();
-        Client.url(rootUrl()).xmlPost(new Sample("toto")).get();
-    	String responseBody = Client.url(rootUrl()).getXml().get().getBody();
+        Client httpClient = new Client();
+    	httpClient.url(rootUrl()).xmlPost(new Sample("toto")). get();
+        httpClient.url(rootUrl()).xmlPost(new Sample("toto")).get();
+    	String responseBody = httpClient.url(rootUrl()).getXml().get().getBody();
         Assertions.assertThat(responseBody).contains("toto");
     }
     
     @Test
     public void testPagingFindAllResources() throws IllegalArgumentException, InterruptedException, ExecutionException, IOException {
-    	Client.url(rootUrl()).xmlPost(new Sample("toto")). get();
-        Client.url(rootUrl()).xmlPost(new Sample("toto")).get();
-    	String responseBody = Client.url(rootUrl() + "/page/0").getXml().get().getBody();
+        Client httpClient = new Client();
+    	httpClient.url(rootUrl()).xmlPost(new Sample("toto")). get();
+        httpClient.url(rootUrl()).xmlPost(new Sample("toto")).get();
+    	String responseBody = httpClient.url(rootUrl() + "/page/0").getXml().get().getBody();
         Assertions.assertThat(responseBody).contains("<totalElements>2</totalElements>");
     }
 
     @Test
     public void testDeleteResource() throws IllegalArgumentException, IOException, InterruptedException, ExecutionException {
+        Client httpClient = new Client();
     	Sample r = new Sample("toto");
-        r = (Sample)Client.url(rootUrl()).xmlPost(r).get().xmlDeserialize(r.getClass());
+        r = httpClient.url(rootUrl()).xmlPost(r).get().xmlDeserialize(r.getClass());
         Assertions.assertThat(r).isNotNull();
 
-        Client.Response response = Client.url(rootUrl() + "/" + r.getId()).delete().get();
+        Client.Response response = httpClient.url(rootUrl() + "/" + r.getId()).delete().get();
         Assertions.assertThat(response.getStatus()).isEqualTo(Http.NO_CONTENT);
         
-        response = Client.url(rootUrl() + "/" + r.getId()).get().get();
+        response = httpClient.url(rootUrl() + "/" + r.getId()).get().get();
         Assertions.assertThat(response.getStatus()).isEqualTo(Http.NOT_FOUND);
     }
 
     @Test
     public void testFindResource() throws IllegalArgumentException, IOException, InterruptedException, ExecutionException {
+        Client httpClient = new Client();
         Sample r = new Sample("toto");
-        r = (Sample)Client.url(rootUrl()).xmlPost(r).get().xmlDeserialize(r.getClass());
+        r = (Sample)httpClient.url(rootUrl()).xmlPost(r).get().xmlDeserialize(r.getClass());
         
-        Client.Response response = Client.url(rootUrl() + "/" + r.getId()).get().get();
+        Client.Response response = httpClient.url(rootUrl() + "/" + r.getId()).get().get();
         Assertions.assertThat(response.getStatus()).isEqualTo(Http.OK);
     }
 
     @Test
     public void testUpdate() throws IllegalArgumentException, IOException, InterruptedException, ExecutionException {
+        Client httpClient = new Client();
         Sample r1 = new Sample("toto");
-        r1 = Client.url(rootUrl()).xmlPost(r1).get().xmlDeserialize(r1.getClass());
+        r1 = httpClient.url(rootUrl()).xmlPost(r1).get().xmlDeserialize(r1.getClass());
         Sample r2 = new Sample(r1);
         r2.setName("titi");
-        r2 = Client.url(rootUrl() + "/" + r1.getId()).xmlPut(r2).get().xmlDeserialize(r2.getClass());
+        r2 = httpClient.url(rootUrl() + "/" + r1.getId()).xmlPut(r2).get().xmlDeserialize(r2.getClass());
         Assertions.assertThat(r1).isNotEqualTo(r2);
         Assertions.assertThat(r1.getName()).contains("toto");
         Assertions.assertThat(r2.getName()).contains("titi");


### PR DESCRIPTION
- added methods to deserialize Java Generics with Jackson TypeReference
- Client should not be all-static because it should be shared amongst requests (because async-http-client creates pools of resources)
- Client configuration (proxy, OAuth2, auth) should be done only once per client
- Client implements Closeable to be used with JDK7 "try-with-resources"
- update tests and Client use
