### PR TITLE
Simplified HTTP Client API

### DIFF
--- a/resthub-web/resthub-web-client/src/main/java/org/resthub/web/Response.java
+++ b/resthub-web/resthub-web-client/src/main/java/org/resthub/web/Response.java
@@ -23,7 +23,7 @@ public class Response {
         this.bodyReaders.addAll(bodyReaders);
     }
 
-    public <T> T getResource(Class<T> type) {
+    public <T> T resource(Class<T> type) {
         try {
             for (BodyReader br : this.bodyReaders) {
                 if (br.canRead(ahcResponse)) {
@@ -37,7 +37,7 @@ public class Response {
         throw new RuntimeException("unsupported media type " + ahcResponse.getContentType());
     }
 
-    public <T> T getResource(TypeReference valueTypeRef) {
+    public <T> T resource(TypeReference valueTypeRef) {
         try {
             for (BodyReader br : this.bodyReaders) {
                 if (br.canRead(ahcResponse)) {

--- a/resthub-web/resthub-web-client/src/main/java/org/resthub/web/Response.java
+++ b/resthub-web/resthub-web-client/src/main/java/org/resthub/web/Response.java
@@ -23,7 +23,7 @@ public class Response {
         this.bodyReaders.addAll(bodyReaders);
     }
 
-    public <T> T getEntity(Class<T> type) {
+    public <T> T getResource(Class<T> type) {
         try {
             for (BodyReader br : this.bodyReaders) {
                 if (br.canRead(ahcResponse)) {
@@ -37,7 +37,7 @@ public class Response {
         throw new RuntimeException("unsupported media type " + ahcResponse.getContentType());
     }
 
-    public <T> T getEntity(TypeReference valueTypeRef) {
+    public <T> T getResource(TypeReference valueTypeRef) {
         try {
             for (BodyReader br : this.bodyReaders) {
                 if (br.canRead(ahcResponse)) {

--- a/resthub-web/resthub-web-client/src/main/java/org/resthub/web/Response.java
+++ b/resthub-web/resthub-web-client/src/main/java/org/resthub/web/Response.java
@@ -1,0 +1,78 @@
+package org.resthub.web;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import org.resthub.web.support.BodyReader;
+
+public class Response {
+
+    private com.ning.http.client.Response ahcResponse;
+    private List<BodyReader> bodyReaders = new ArrayList<>();
+
+    public Response(com.ning.http.client.Response ahcResponse) {
+        this.ahcResponse = ahcResponse;
+    }
+
+    public void addBodyReader(BodyReader br) {
+        this.bodyReaders.add(br);
+    }
+
+    public void addBodyReaders(List<BodyReader> bodyReaders) {
+        this.bodyReaders.addAll(bodyReaders);
+    }
+
+    public <T> T getEntity(Class<T> type) {
+        try {
+            for (BodyReader br : this.bodyReaders) {
+                if (br.canRead(ahcResponse)) {
+                    return br.readEntity(ahcResponse, type);
+                }
+            }
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        throw new RuntimeException("unsupported media type " + ahcResponse.getContentType());
+    }
+
+    public <T> T getEntity(TypeReference valueTypeRef) {
+        try {
+            for (BodyReader br : this.bodyReaders) {
+                if (br.canRead(ahcResponse)) {
+                    return br.readEntity(ahcResponse, valueTypeRef);
+                }
+            }
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        throw new RuntimeException("unsupported media type " + ahcResponse.getContentType());
+    }
+
+    /**
+     * Get the HTTP status code of the response
+     */
+    public int getStatus() {
+        return ahcResponse.getStatusCode();
+    }
+
+    /**
+     * Get the given HTTP header of the response
+     */
+    public String getHeader(String key) {
+        return ahcResponse.getHeader(key);
+    }
+
+    /**
+     * Get the response body as a string
+     */
+    public String getBody() {
+        try {
+            return ahcResponse.getResponseBody();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/resthub-web/resthub-web-client/src/main/java/org/resthub/web/support/AsyncEntityHandler.java
+++ b/resthub-web/resthub-web-client/src/main/java/org/resthub/web/support/AsyncEntityHandler.java
@@ -1,0 +1,29 @@
+package org.resthub.web.support;
+
+import com.ning.http.client.AsyncCompletionHandler;
+import java.util.ArrayList;
+import java.util.List;
+import org.resthub.web.Response;
+
+public class AsyncEntityHandler extends AsyncCompletionHandler<Response> {
+    
+    protected List<BodyReader> bodyReaders = new ArrayList<>();
+    
+    public void setBodyReaders(List<BodyReader> brs) {
+        this.bodyReaders = brs;
+    }
+    
+    public void addBodyReader(BodyReader br) {
+        this.bodyReaders.add(br);
+    }
+
+    @Override
+    public Response onCompleted(com.ning.http.client.Response rspns) throws Exception {
+        
+        Response resp = new Response(rspns);
+        resp.addBodyReaders(this.bodyReaders);
+        
+        return resp;
+    }
+    
+}

--- a/resthub-web/resthub-web-client/src/main/java/org/resthub/web/support/BodyReader.java
+++ b/resthub-web/resthub-web-client/src/main/java/org/resthub/web/support/BodyReader.java
@@ -1,0 +1,14 @@
+package org.resthub.web.support;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.ning.http.client.Response;
+import java.io.IOException;
+
+public interface BodyReader {
+
+    public boolean canRead(Response response);
+
+    public <T> T readEntity(Response resp, Class<T> entityClass) throws IOException;
+
+    public <T> T readEntity(Response resp, TypeReference valueTypeRef) throws IOException;
+}

--- a/resthub-web/resthub-web-client/src/main/java/org/resthub/web/support/BodyWriter.java
+++ b/resthub-web/resthub-web-client/src/main/java/org/resthub/web/support/BodyWriter.java
@@ -1,0 +1,11 @@
+package org.resthub.web.support;
+
+import org.resthub.web.Client;
+
+public interface BodyWriter {
+  
+    public boolean canWrite(String mediaType);
+
+    public String writeEntity(String mediaType, Object object);
+
+}

--- a/resthub-web/resthub-web-client/src/main/java/org/resthub/web/support/JsonBodyReader.java
+++ b/resthub-web/resthub-web-client/src/main/java/org/resthub/web/support/JsonBodyReader.java
@@ -1,0 +1,29 @@
+package org.resthub.web.support;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.ning.http.client.Response;
+import java.io.IOException;
+import org.resthub.web.Http;
+import org.resthub.web.JsonHelper;
+
+public class JsonBodyReader implements BodyReader {
+
+    @Override
+    public boolean canRead(Response response) {
+
+        return (response.getContentType() != null
+                && (response.getContentType().startsWith(Http.JSON) || response.getContentType().endsWith("+json")));
+    }
+
+    @Override
+    public <T> T readEntity(Response resp, Class<T> entityClass) throws IOException {
+
+        return JsonHelper.deserialize(resp.getResponseBody(), entityClass);
+    }
+
+    @Override
+    public <T> T readEntity(Response resp, TypeReference valueTypeRef) throws IOException {
+
+        return JsonHelper.deserialize(resp.getResponseBody(), valueTypeRef);
+    }
+}

--- a/resthub-web/resthub-web-client/src/main/java/org/resthub/web/support/JsonBodyWriter.java
+++ b/resthub-web/resthub-web-client/src/main/java/org/resthub/web/support/JsonBodyWriter.java
@@ -1,0 +1,20 @@
+package org.resthub.web.support;
+
+import org.resthub.web.Client.Request;
+import org.resthub.web.Http;
+import org.resthub.web.JsonHelper;
+
+public class JsonBodyWriter implements BodyWriter {
+
+    @Override
+    public boolean canWrite(String mediaType) {
+        return (mediaType != null && 
+                (mediaType.startsWith(Http.JSON) || mediaType.endsWith("+json")));
+    }
+
+    @Override
+    public String writeEntity(String mediaType, Object object) {
+        return JsonHelper.serialize(object);
+    }
+    
+}

--- a/resthub-web/resthub-web-client/src/main/java/org/resthub/web/support/XmlBodyReader.java
+++ b/resthub-web/resthub-web-client/src/main/java/org/resthub/web/support/XmlBodyReader.java
@@ -1,0 +1,26 @@
+package org.resthub.web.support;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.ning.http.client.Response;
+import java.io.IOException;
+import org.resthub.web.Http;
+import org.resthub.web.XmlHelper;
+
+public class XmlBodyReader implements BodyReader {
+
+    @Override
+    public boolean canRead(Response response) {
+        return (response.getContentType() != null
+                && (response.getContentType().startsWith(Http.XML) || response.getContentType().endsWith("+xml")));
+    }
+
+    @Override
+    public <T> T readEntity(Response resp, Class<T> entityClass) throws IOException {
+        return XmlHelper.deserialize(resp.getResponseBody(), entityClass);
+    }
+
+    @Override
+    public <T> T readEntity(Response resp, TypeReference valueTypeRef) throws IOException {
+        return XmlHelper.deserialize(resp.getResponseBody(), valueTypeRef);
+    }
+}

--- a/resthub-web/resthub-web-client/src/main/java/org/resthub/web/support/XmlBodyWriter.java
+++ b/resthub-web/resthub-web-client/src/main/java/org/resthub/web/support/XmlBodyWriter.java
@@ -1,0 +1,19 @@
+package org.resthub.web.support;
+
+import org.resthub.web.Client.Request;
+import org.resthub.web.Http;
+import org.resthub.web.XmlHelper;
+
+public class XmlBodyWriter implements BodyWriter {
+
+    @Override
+    public boolean canWrite(String mediaType) {
+        return (mediaType != null
+                && (mediaType.startsWith(Http.XML) || mediaType.endsWith("+xml")));
+    }
+
+    @Override
+    public String writeEntity(String mediaType, Object object) {
+        return XmlHelper.serialize(object);
+    }
+}

--- a/resthub-web/resthub-web-client/src/test/java/org/resthub/web/oauth2/TestOAuth2Client.java
+++ b/resthub-web/resthub-web-client/src/test/java/org/resthub/web/oauth2/TestOAuth2Client.java
@@ -12,7 +12,7 @@ import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
 import org.fest.assertions.api.Assertions;
 import org.resthub.web.Client;
-import org.resthub.web.Client.Response;
+import org.resthub.web.Response;
 import org.resthub.web.Http;
 import org.springframework.web.filter.DelegatingFilterProxy;
 import org.springframework.web.servlet.DispatcherServlet;

--- a/resthub-web/resthub-web-server/src/test/java/org/resthub/web/controller/JsonRepositoryBasedRestControllerTest.java
+++ b/resthub-web/resthub-web-server/src/test/java/org/resthub/web/controller/JsonRepositoryBasedRestControllerTest.java
@@ -31,7 +31,7 @@ public class JsonRepositoryBasedRestControllerTest extends AbstractWebTest {
             IOException {
         Sample r = new Sample("toto");
         Response response = new Client().url(rootUrl()).jsonPost(r).get();
-        r = (Sample)response.getEntity(r.getClass());
+        r = (Sample)response.getResource(r.getClass());
         Assertions.assertThat(r).isNotNull();
         Assertions.assertThat(r.getName()).isEqualTo("toto");
     }
@@ -58,7 +58,7 @@ public class JsonRepositoryBasedRestControllerTest extends AbstractWebTest {
     public void testDeleteResource() throws IllegalArgumentException, IOException, InterruptedException, ExecutionException {
         Client httpClient = new Client();
     	Sample r = new Sample("toto");
-        r = httpClient.url(rootUrl()).jsonPost(r).get().getEntity(r.getClass());
+        r = httpClient.url(rootUrl()).jsonPost(r).get().getResource(r.getClass());
         Assertions.assertThat(r).isNotNull();
 
         Response response = httpClient.url(rootUrl() + "/" + r.getId()).delete().get();
@@ -71,7 +71,7 @@ public class JsonRepositoryBasedRestControllerTest extends AbstractWebTest {
     public void testFindResource() throws IllegalArgumentException, IOException, InterruptedException, ExecutionException {
         Client httpClient = new Client();
         Sample r = new Sample("toto");
-        r = httpClient.url(rootUrl()).jsonPost(r).get().getEntity(r.getClass());
+        r = httpClient.url(rootUrl()).jsonPost(r).get().getResource(r.getClass());
         
         Response response = httpClient.url(rootUrl() + "/" + r.getId()).get().get();
         Assertions.assertThat(response.getStatus()).isEqualTo(Http.OK);
@@ -81,10 +81,10 @@ public class JsonRepositoryBasedRestControllerTest extends AbstractWebTest {
     public void testUpdate() throws IllegalArgumentException, IOException, InterruptedException, ExecutionException {
         Client httpClient = new Client();
         Sample r1 = new Sample("toto");
-        r1 = httpClient.url(rootUrl()).jsonPost(r1).get().getEntity(r1.getClass());
+        r1 = httpClient.url(rootUrl()).jsonPost(r1).get().getResource(r1.getClass());
         Sample r2 = new Sample(r1);
         r2.setName("titi");
-        r2 = httpClient.url(rootUrl() + "/" + r1.getId()).jsonPut(r2).get().getEntity(r2.getClass());
+        r2 = httpClient.url(rootUrl() + "/" + r1.getId()).jsonPut(r2).get().getResource(r2.getClass());
         Assertions.assertThat(r1).isNotEqualTo(r2);
         Assertions.assertThat(r1.getName()).contains("toto");
         Assertions.assertThat(r2.getName()).contains("titi");

--- a/resthub-web/resthub-web-server/src/test/java/org/resthub/web/controller/JsonRepositoryBasedRestControllerTest.java
+++ b/resthub-web/resthub-web-server/src/test/java/org/resthub/web/controller/JsonRepositoryBasedRestControllerTest.java
@@ -31,7 +31,7 @@ public class JsonRepositoryBasedRestControllerTest extends AbstractWebTest {
             IOException {
         Sample r = new Sample("toto");
         Response response = new Client().url(rootUrl()).jsonPost(r).get();
-        r = (Sample)response.getResource(r.getClass());
+        r = (Sample)response.resource(r.getClass());
         Assertions.assertThat(r).isNotNull();
         Assertions.assertThat(r.getName()).isEqualTo("toto");
     }
@@ -58,7 +58,7 @@ public class JsonRepositoryBasedRestControllerTest extends AbstractWebTest {
     public void testDeleteResource() throws IllegalArgumentException, IOException, InterruptedException, ExecutionException {
         Client httpClient = new Client();
     	Sample r = new Sample("toto");
-        r = httpClient.url(rootUrl()).jsonPost(r).get().getResource(r.getClass());
+        r = httpClient.url(rootUrl()).jsonPost(r).get().resource(r.getClass());
         Assertions.assertThat(r).isNotNull();
 
         Response response = httpClient.url(rootUrl() + "/" + r.getId()).delete().get();
@@ -71,7 +71,7 @@ public class JsonRepositoryBasedRestControllerTest extends AbstractWebTest {
     public void testFindResource() throws IllegalArgumentException, IOException, InterruptedException, ExecutionException {
         Client httpClient = new Client();
         Sample r = new Sample("toto");
-        r = httpClient.url(rootUrl()).jsonPost(r).get().getResource(r.getClass());
+        r = httpClient.url(rootUrl()).jsonPost(r).get().resource(r.getClass());
         
         Response response = httpClient.url(rootUrl() + "/" + r.getId()).get().get();
         Assertions.assertThat(response.getStatus()).isEqualTo(Http.OK);
@@ -81,10 +81,10 @@ public class JsonRepositoryBasedRestControllerTest extends AbstractWebTest {
     public void testUpdate() throws IllegalArgumentException, IOException, InterruptedException, ExecutionException {
         Client httpClient = new Client();
         Sample r1 = new Sample("toto");
-        r1 = httpClient.url(rootUrl()).jsonPost(r1).get().getResource(r1.getClass());
+        r1 = httpClient.url(rootUrl()).jsonPost(r1).get().resource(r1.getClass());
         Sample r2 = new Sample(r1);
         r2.setName("titi");
-        r2 = httpClient.url(rootUrl() + "/" + r1.getId()).jsonPut(r2).get().getResource(r2.getClass());
+        r2 = httpClient.url(rootUrl() + "/" + r1.getId()).jsonPut(r2).get().resource(r2.getClass());
         Assertions.assertThat(r1).isNotEqualTo(r2);
         Assertions.assertThat(r1.getName()).contains("toto");
         Assertions.assertThat(r2.getName()).contains("titi");

--- a/resthub-web/resthub-web-server/src/test/java/org/resthub/web/controller/JsonRepositoryBasedRestControllerTest.java
+++ b/resthub-web/resthub-web-server/src/test/java/org/resthub/web/controller/JsonRepositoryBasedRestControllerTest.java
@@ -6,6 +6,7 @@ import org.fest.assertions.api.Assertions;
 import org.resthub.test.common.AbstractWebTest;
 import org.resthub.web.Client;
 import org.resthub.web.Http;
+import org.resthub.web.Response;
 import org.resthub.web.model.Sample;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Test;
@@ -29,8 +30,8 @@ public class JsonRepositoryBasedRestControllerTest extends AbstractWebTest {
     public void testCreateResource() throws IllegalArgumentException, InterruptedException, ExecutionException,
             IOException {
         Sample r = new Sample("toto");
-        Client.Response response = new Client().url(rootUrl()).jsonPost(r).get();
-        r = (Sample)response.jsonDeserialize(r.getClass());
+        Response response = new Client().url(rootUrl()).jsonPost(r).get();
+        r = (Sample)response.getEntity(r.getClass());
         Assertions.assertThat(r).isNotNull();
         Assertions.assertThat(r.getName()).isEqualTo("toto");
     }
@@ -57,10 +58,10 @@ public class JsonRepositoryBasedRestControllerTest extends AbstractWebTest {
     public void testDeleteResource() throws IllegalArgumentException, IOException, InterruptedException, ExecutionException {
         Client httpClient = new Client();
     	Sample r = new Sample("toto");
-        r = httpClient.url(rootUrl()).jsonPost(r).get().jsonDeserialize(r.getClass());
+        r = httpClient.url(rootUrl()).jsonPost(r).get().getEntity(r.getClass());
         Assertions.assertThat(r).isNotNull();
 
-        Client.Response response = httpClient.url(rootUrl() + "/" + r.getId()).delete().get();
+        Response response = httpClient.url(rootUrl() + "/" + r.getId()).delete().get();
         Assertions.assertThat(response.getStatus()).isEqualTo(Http.NO_CONTENT);
         response = httpClient.url(rootUrl() + "/" + r.getId()).get().get();
         Assertions.assertThat(response.getStatus()).isEqualTo(Http.NOT_FOUND);
@@ -70,9 +71,9 @@ public class JsonRepositoryBasedRestControllerTest extends AbstractWebTest {
     public void testFindResource() throws IllegalArgumentException, IOException, InterruptedException, ExecutionException {
         Client httpClient = new Client();
         Sample r = new Sample("toto");
-        r = httpClient.url(rootUrl()).jsonPost(r).get().jsonDeserialize(r.getClass());
+        r = httpClient.url(rootUrl()).jsonPost(r).get().getEntity(r.getClass());
         
-        Client.Response response = httpClient.url(rootUrl() + "/" + r.getId()).get().get();
+        Response response = httpClient.url(rootUrl() + "/" + r.getId()).get().get();
         Assertions.assertThat(response.getStatus()).isEqualTo(Http.OK);
     }
 
@@ -80,10 +81,10 @@ public class JsonRepositoryBasedRestControllerTest extends AbstractWebTest {
     public void testUpdate() throws IllegalArgumentException, IOException, InterruptedException, ExecutionException {
         Client httpClient = new Client();
         Sample r1 = new Sample("toto");
-        r1 = httpClient.url(rootUrl()).jsonPost(r1).get().jsonDeserialize(r1.getClass());
+        r1 = httpClient.url(rootUrl()).jsonPost(r1).get().getEntity(r1.getClass());
         Sample r2 = new Sample(r1);
         r2.setName("titi");
-        r2 = httpClient.url(rootUrl() + "/" + r1.getId()).jsonPut(r2).get().jsonDeserialize(r2.getClass());
+        r2 = httpClient.url(rootUrl() + "/" + r1.getId()).jsonPut(r2).get().getEntity(r2.getClass());
         Assertions.assertThat(r1).isNotEqualTo(r2);
         Assertions.assertThat(r1.getName()).contains("toto");
         Assertions.assertThat(r2.getName()).contains("titi");

--- a/resthub-web/resthub-web-server/src/test/java/org/resthub/web/controller/JsonServiceBasedRestControllerTest.java
+++ b/resthub-web/resthub-web-server/src/test/java/org/resthub/web/controller/JsonServiceBasedRestControllerTest.java
@@ -31,7 +31,7 @@ public class JsonServiceBasedRestControllerTest extends AbstractWebTest {
         Client httpClient = new Client();
         Sample r = new Sample("toto");
         Response response = httpClient.url(rootUrl()).jsonPost(r).get();
-        r = (Sample)response.getEntity(r.getClass());
+        r = (Sample)response.getResource(r.getClass());
         Assertions.assertThat(r).isNotNull();
         Assertions.assertThat(r.getName()).isEqualTo("toto");
     }
@@ -58,7 +58,7 @@ public class JsonServiceBasedRestControllerTest extends AbstractWebTest {
     public void testDeleteResource() throws IllegalArgumentException, IOException, InterruptedException, ExecutionException {
         Client httpClient = new Client();
     	Sample r = new Sample("toto");
-        r = httpClient.url(rootUrl()).jsonPost(r).get().getEntity(r.getClass());
+        r = httpClient.url(rootUrl()).jsonPost(r).get().getResource(r.getClass());
         Assertions.assertThat(r).isNotNull();
 
         Response response = httpClient.url(rootUrl() + "/" + r.getId()).delete().get();
@@ -72,7 +72,7 @@ public class JsonServiceBasedRestControllerTest extends AbstractWebTest {
     public void testFindResource() throws IllegalArgumentException, IOException, InterruptedException, ExecutionException {
         Client httpClient = new Client();
         Sample r = new Sample("toto");
-        r = httpClient.url(rootUrl()).jsonPost(r).get().getEntity(r.getClass());
+        r = httpClient.url(rootUrl()).jsonPost(r).get().getResource(r.getClass());
         
         Response response = httpClient.url(rootUrl() + "/" + r.getId()).get().get();
         Assertions.assertThat(response.getStatus()).isEqualTo(Http.OK);
@@ -82,10 +82,10 @@ public class JsonServiceBasedRestControllerTest extends AbstractWebTest {
     public void testUpdate() throws IllegalArgumentException, IOException, InterruptedException, ExecutionException {
         Client httpClient = new Client();
         Sample r1 = new Sample("toto");
-        r1 = httpClient.url(rootUrl()).jsonPost(r1).get().getEntity(r1.getClass());
+        r1 = httpClient.url(rootUrl()).jsonPost(r1).get().getResource(r1.getClass());
         Sample r2 = new Sample(r1);
         r2.setName("titi");
-        r2 = httpClient.url(rootUrl() + "/" + r1.getId()).jsonPut(r2).get().getEntity(r2.getClass());
+        r2 = httpClient.url(rootUrl() + "/" + r1.getId()).jsonPut(r2).get().getResource(r2.getClass());
         Assertions.assertThat(r1).isNotEqualTo(r2);
         Assertions.assertThat(r1.getName()).contains("toto");
         Assertions.assertThat(r2.getName()).contains("titi");

--- a/resthub-web/resthub-web-server/src/test/java/org/resthub/web/controller/JsonServiceBasedRestControllerTest.java
+++ b/resthub-web/resthub-web-server/src/test/java/org/resthub/web/controller/JsonServiceBasedRestControllerTest.java
@@ -31,7 +31,7 @@ public class JsonServiceBasedRestControllerTest extends AbstractWebTest {
         Client httpClient = new Client();
         Sample r = new Sample("toto");
         Response response = httpClient.url(rootUrl()).jsonPost(r).get();
-        r = (Sample)response.getResource(r.getClass());
+        r = (Sample)response.resource(r.getClass());
         Assertions.assertThat(r).isNotNull();
         Assertions.assertThat(r.getName()).isEqualTo("toto");
     }
@@ -58,7 +58,7 @@ public class JsonServiceBasedRestControllerTest extends AbstractWebTest {
     public void testDeleteResource() throws IllegalArgumentException, IOException, InterruptedException, ExecutionException {
         Client httpClient = new Client();
     	Sample r = new Sample("toto");
-        r = httpClient.url(rootUrl()).jsonPost(r).get().getResource(r.getClass());
+        r = httpClient.url(rootUrl()).jsonPost(r).get().resource(r.getClass());
         Assertions.assertThat(r).isNotNull();
 
         Response response = httpClient.url(rootUrl() + "/" + r.getId()).delete().get();
@@ -72,7 +72,7 @@ public class JsonServiceBasedRestControllerTest extends AbstractWebTest {
     public void testFindResource() throws IllegalArgumentException, IOException, InterruptedException, ExecutionException {
         Client httpClient = new Client();
         Sample r = new Sample("toto");
-        r = httpClient.url(rootUrl()).jsonPost(r).get().getResource(r.getClass());
+        r = httpClient.url(rootUrl()).jsonPost(r).get().resource(r.getClass());
         
         Response response = httpClient.url(rootUrl() + "/" + r.getId()).get().get();
         Assertions.assertThat(response.getStatus()).isEqualTo(Http.OK);
@@ -82,10 +82,10 @@ public class JsonServiceBasedRestControllerTest extends AbstractWebTest {
     public void testUpdate() throws IllegalArgumentException, IOException, InterruptedException, ExecutionException {
         Client httpClient = new Client();
         Sample r1 = new Sample("toto");
-        r1 = httpClient.url(rootUrl()).jsonPost(r1).get().getResource(r1.getClass());
+        r1 = httpClient.url(rootUrl()).jsonPost(r1).get().resource(r1.getClass());
         Sample r2 = new Sample(r1);
         r2.setName("titi");
-        r2 = httpClient.url(rootUrl() + "/" + r1.getId()).jsonPut(r2).get().getResource(r2.getClass());
+        r2 = httpClient.url(rootUrl() + "/" + r1.getId()).jsonPut(r2).get().resource(r2.getClass());
         Assertions.assertThat(r1).isNotEqualTo(r2);
         Assertions.assertThat(r1.getName()).contains("toto");
         Assertions.assertThat(r2.getName()).contains("titi");

--- a/resthub-web/resthub-web-server/src/test/java/org/resthub/web/controller/JsonServiceBasedRestControllerTest.java
+++ b/resthub-web/resthub-web-server/src/test/java/org/resthub/web/controller/JsonServiceBasedRestControllerTest.java
@@ -6,6 +6,7 @@ import org.fest.assertions.api.Assertions;
 import org.resthub.test.common.AbstractWebTest;
 import org.resthub.web.Client;
 import org.resthub.web.Http;
+import org.resthub.web.Response;
 import org.resthub.web.model.Sample;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Test;
@@ -29,8 +30,8 @@ public class JsonServiceBasedRestControllerTest extends AbstractWebTest {
     public void testCreateResource() throws IllegalArgumentException, InterruptedException, ExecutionException, IOException {
         Client httpClient = new Client();
         Sample r = new Sample("toto");
-        Client.Response response = httpClient.url(rootUrl()).jsonPost(r).get();
-        r = (Sample)response.jsonDeserialize(r.getClass());
+        Response response = httpClient.url(rootUrl()).jsonPost(r).get();
+        r = (Sample)response.getEntity(r.getClass());
         Assertions.assertThat(r).isNotNull();
         Assertions.assertThat(r.getName()).isEqualTo("toto");
     }
@@ -57,10 +58,10 @@ public class JsonServiceBasedRestControllerTest extends AbstractWebTest {
     public void testDeleteResource() throws IllegalArgumentException, IOException, InterruptedException, ExecutionException {
         Client httpClient = new Client();
     	Sample r = new Sample("toto");
-        r = httpClient.url(rootUrl()).jsonPost(r).get().jsonDeserialize(r.getClass());
+        r = httpClient.url(rootUrl()).jsonPost(r).get().getEntity(r.getClass());
         Assertions.assertThat(r).isNotNull();
 
-        Client.Response response = httpClient.url(rootUrl() + "/" + r.getId()).delete().get();
+        Response response = httpClient.url(rootUrl() + "/" + r.getId()).delete().get();
         Assertions.assertThat(response.getStatus()).isEqualTo(Http.NO_CONTENT);
        
         response = httpClient.url(rootUrl() + "/" + r.getId()).get().get();
@@ -71,9 +72,9 @@ public class JsonServiceBasedRestControllerTest extends AbstractWebTest {
     public void testFindResource() throws IllegalArgumentException, IOException, InterruptedException, ExecutionException {
         Client httpClient = new Client();
         Sample r = new Sample("toto");
-        r = httpClient.url(rootUrl()).jsonPost(r).get().jsonDeserialize(r.getClass());
+        r = httpClient.url(rootUrl()).jsonPost(r).get().getEntity(r.getClass());
         
-        Client.Response response = httpClient.url(rootUrl() + "/" + r.getId()).get().get();
+        Response response = httpClient.url(rootUrl() + "/" + r.getId()).get().get();
         Assertions.assertThat(response.getStatus()).isEqualTo(Http.OK);
     }
 
@@ -81,10 +82,10 @@ public class JsonServiceBasedRestControllerTest extends AbstractWebTest {
     public void testUpdate() throws IllegalArgumentException, IOException, InterruptedException, ExecutionException {
         Client httpClient = new Client();
         Sample r1 = new Sample("toto");
-        r1 = httpClient.url(rootUrl()).jsonPost(r1).get().jsonDeserialize(r1.getClass());
+        r1 = httpClient.url(rootUrl()).jsonPost(r1).get().getEntity(r1.getClass());
         Sample r2 = new Sample(r1);
         r2.setName("titi");
-        r2 = httpClient.url(rootUrl() + "/" + r1.getId()).jsonPut(r2).get().jsonDeserialize(r2.getClass());
+        r2 = httpClient.url(rootUrl() + "/" + r1.getId()).jsonPut(r2).get().getEntity(r2.getClass());
         Assertions.assertThat(r1).isNotEqualTo(r2);
         Assertions.assertThat(r1.getName()).contains("toto");
         Assertions.assertThat(r2.getName()).contains("titi");

--- a/resthub-web/resthub-web-server/src/test/java/org/resthub/web/controller/XmlRepositoryBasedRestControllerWebTest.java
+++ b/resthub-web/resthub-web-server/src/test/java/org/resthub/web/controller/XmlRepositoryBasedRestControllerWebTest.java
@@ -6,6 +6,7 @@ import org.fest.assertions.api.Assertions;
 import org.resthub.test.common.AbstractWebTest;
 import org.resthub.web.Client;
 import org.resthub.web.Http;
+import org.resthub.web.Response;
 import org.resthub.web.model.Sample;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Test;
@@ -29,8 +30,8 @@ public class XmlRepositoryBasedRestControllerWebTest extends AbstractWebTest {
     public void testCreateResource() throws IllegalArgumentException, InterruptedException, ExecutionException, IOException {
         Client httpClient = new Client();
         Sample r = new Sample("toto");
-        Client.Response response = httpClient.url(rootUrl()).xmlPost(r).get();
-        r = (Sample)response.xmlDeserialize(r.getClass());
+        Response response = httpClient.url(rootUrl()).xmlPost(r).get();
+        r = (Sample)response.getEntity(r.getClass());
         Assertions.assertThat(r).isNotNull();
         Assertions.assertThat(r.getName()).isEqualTo("toto");
     }
@@ -57,10 +58,10 @@ public class XmlRepositoryBasedRestControllerWebTest extends AbstractWebTest {
     public void testDeleteResource() throws IllegalArgumentException, IOException, InterruptedException, ExecutionException {
         Client httpClient = new Client();
     	Sample r = new Sample("toto");
-        r = (Sample)httpClient.url(rootUrl()).xmlPost(r).get().xmlDeserialize(r.getClass());
+        r = (Sample)httpClient.url(rootUrl()).xmlPost(r).get().getEntity(r.getClass());
         Assertions.assertThat(r).isNotNull();
 
-        Client.Response response = httpClient.url(rootUrl() + "/" + r.getId()).delete().get();
+        Response response = httpClient.url(rootUrl() + "/" + r.getId()).delete().get();
         Assertions.assertThat(response.getStatus()).isEqualTo(Http.NO_CONTENT);
 
         response = httpClient.url(rootUrl() + "/" + r.getId()).get().get();
@@ -71,9 +72,9 @@ public class XmlRepositoryBasedRestControllerWebTest extends AbstractWebTest {
     public void testFindResource() throws IllegalArgumentException, IOException, InterruptedException, ExecutionException {
         Client httpClient = new Client();
         Sample r = new Sample("toto");
-        r = (Sample)httpClient.url(rootUrl()).xmlPost(r).get().xmlDeserialize(r.getClass());
+        r = (Sample)httpClient.url(rootUrl()).xmlPost(r).get().getEntity(r.getClass());
         
-        Client.Response response = httpClient.url(rootUrl() + "/" + r.getId()).get().get();
+        Response response = httpClient.url(rootUrl() + "/" + r.getId()).get().get();
         Assertions.assertThat(response.getStatus()).isEqualTo(Http.OK);
     }
 
@@ -81,10 +82,10 @@ public class XmlRepositoryBasedRestControllerWebTest extends AbstractWebTest {
     public void testUpdate() throws IllegalArgumentException, IOException, InterruptedException, ExecutionException {
         Client httpClient = new Client();
         Sample r1 = new Sample("toto");
-        r1 = httpClient.url(rootUrl()).xmlPost(r1).get().xmlDeserialize(r1.getClass());
+        r1 = httpClient.url(rootUrl()).xmlPost(r1).get().getEntity(r1.getClass());
         Sample r2 = new Sample(r1);
         r2.setName("titi");
-        r2 = httpClient.url(rootUrl() + "/" + r1.getId()).xmlPut(r2).get().xmlDeserialize(r2.getClass());
+        r2 = httpClient.url(rootUrl() + "/" + r1.getId()).xmlPut(r2).get().getEntity(r2.getClass());
         Assertions.assertThat(r1).isNotEqualTo(r2);
         Assertions.assertThat(r1.getName()).contains("toto");
         Assertions.assertThat(r2.getName()).contains("titi");

--- a/resthub-web/resthub-web-server/src/test/java/org/resthub/web/controller/XmlRepositoryBasedRestControllerWebTest.java
+++ b/resthub-web/resthub-web-server/src/test/java/org/resthub/web/controller/XmlRepositoryBasedRestControllerWebTest.java
@@ -31,7 +31,7 @@ public class XmlRepositoryBasedRestControllerWebTest extends AbstractWebTest {
         Client httpClient = new Client();
         Sample r = new Sample("toto");
         Response response = httpClient.url(rootUrl()).xmlPost(r).get();
-        r = (Sample)response.getEntity(r.getClass());
+        r = (Sample)response.getResource(r.getClass());
         Assertions.assertThat(r).isNotNull();
         Assertions.assertThat(r.getName()).isEqualTo("toto");
     }
@@ -58,7 +58,7 @@ public class XmlRepositoryBasedRestControllerWebTest extends AbstractWebTest {
     public void testDeleteResource() throws IllegalArgumentException, IOException, InterruptedException, ExecutionException {
         Client httpClient = new Client();
     	Sample r = new Sample("toto");
-        r = (Sample)httpClient.url(rootUrl()).xmlPost(r).get().getEntity(r.getClass());
+        r = (Sample)httpClient.url(rootUrl()).xmlPost(r).get().getResource(r.getClass());
         Assertions.assertThat(r).isNotNull();
 
         Response response = httpClient.url(rootUrl() + "/" + r.getId()).delete().get();
@@ -72,7 +72,7 @@ public class XmlRepositoryBasedRestControllerWebTest extends AbstractWebTest {
     public void testFindResource() throws IllegalArgumentException, IOException, InterruptedException, ExecutionException {
         Client httpClient = new Client();
         Sample r = new Sample("toto");
-        r = (Sample)httpClient.url(rootUrl()).xmlPost(r).get().getEntity(r.getClass());
+        r = (Sample)httpClient.url(rootUrl()).xmlPost(r).get().getResource(r.getClass());
         
         Response response = httpClient.url(rootUrl() + "/" + r.getId()).get().get();
         Assertions.assertThat(response.getStatus()).isEqualTo(Http.OK);
@@ -82,10 +82,10 @@ public class XmlRepositoryBasedRestControllerWebTest extends AbstractWebTest {
     public void testUpdate() throws IllegalArgumentException, IOException, InterruptedException, ExecutionException {
         Client httpClient = new Client();
         Sample r1 = new Sample("toto");
-        r1 = httpClient.url(rootUrl()).xmlPost(r1).get().getEntity(r1.getClass());
+        r1 = httpClient.url(rootUrl()).xmlPost(r1).get().getResource(r1.getClass());
         Sample r2 = new Sample(r1);
         r2.setName("titi");
-        r2 = httpClient.url(rootUrl() + "/" + r1.getId()).xmlPut(r2).get().getEntity(r2.getClass());
+        r2 = httpClient.url(rootUrl() + "/" + r1.getId()).xmlPut(r2).get().getResource(r2.getClass());
         Assertions.assertThat(r1).isNotEqualTo(r2);
         Assertions.assertThat(r1.getName()).contains("toto");
         Assertions.assertThat(r2.getName()).contains("titi");

--- a/resthub-web/resthub-web-server/src/test/java/org/resthub/web/controller/XmlRepositoryBasedRestControllerWebTest.java
+++ b/resthub-web/resthub-web-server/src/test/java/org/resthub/web/controller/XmlRepositoryBasedRestControllerWebTest.java
@@ -31,7 +31,7 @@ public class XmlRepositoryBasedRestControllerWebTest extends AbstractWebTest {
         Client httpClient = new Client();
         Sample r = new Sample("toto");
         Response response = httpClient.url(rootUrl()).xmlPost(r).get();
-        r = (Sample)response.getResource(r.getClass());
+        r = (Sample)response.resource(r.getClass());
         Assertions.assertThat(r).isNotNull();
         Assertions.assertThat(r.getName()).isEqualTo("toto");
     }
@@ -58,7 +58,7 @@ public class XmlRepositoryBasedRestControllerWebTest extends AbstractWebTest {
     public void testDeleteResource() throws IllegalArgumentException, IOException, InterruptedException, ExecutionException {
         Client httpClient = new Client();
     	Sample r = new Sample("toto");
-        r = (Sample)httpClient.url(rootUrl()).xmlPost(r).get().getResource(r.getClass());
+        r = (Sample)httpClient.url(rootUrl()).xmlPost(r).get().resource(r.getClass());
         Assertions.assertThat(r).isNotNull();
 
         Response response = httpClient.url(rootUrl() + "/" + r.getId()).delete().get();
@@ -72,7 +72,7 @@ public class XmlRepositoryBasedRestControllerWebTest extends AbstractWebTest {
     public void testFindResource() throws IllegalArgumentException, IOException, InterruptedException, ExecutionException {
         Client httpClient = new Client();
         Sample r = new Sample("toto");
-        r = (Sample)httpClient.url(rootUrl()).xmlPost(r).get().getResource(r.getClass());
+        r = (Sample)httpClient.url(rootUrl()).xmlPost(r).get().resource(r.getClass());
         
         Response response = httpClient.url(rootUrl() + "/" + r.getId()).get().get();
         Assertions.assertThat(response.getStatus()).isEqualTo(Http.OK);
@@ -82,10 +82,10 @@ public class XmlRepositoryBasedRestControllerWebTest extends AbstractWebTest {
     public void testUpdate() throws IllegalArgumentException, IOException, InterruptedException, ExecutionException {
         Client httpClient = new Client();
         Sample r1 = new Sample("toto");
-        r1 = httpClient.url(rootUrl()).xmlPost(r1).get().getResource(r1.getClass());
+        r1 = httpClient.url(rootUrl()).xmlPost(r1).get().resource(r1.getClass());
         Sample r2 = new Sample(r1);
         r2.setName("titi");
-        r2 = httpClient.url(rootUrl() + "/" + r1.getId()).xmlPut(r2).get().getResource(r2.getClass());
+        r2 = httpClient.url(rootUrl() + "/" + r1.getId()).xmlPut(r2).get().resource(r2.getClass());
         Assertions.assertThat(r1).isNotEqualTo(r2);
         Assertions.assertThat(r1.getName()).contains("toto");
         Assertions.assertThat(r2.getName()).contains("titi");

--- a/resthub-web/resthub-web-server/src/test/java/org/resthub/web/controller/XmlServiceBasedRestControllerWebTest.java
+++ b/resthub-web/resthub-web-server/src/test/java/org/resthub/web/controller/XmlServiceBasedRestControllerWebTest.java
@@ -31,7 +31,7 @@ public class XmlServiceBasedRestControllerWebTest extends AbstractWebTest {
         Client httpClient = new Client();
         Sample r = new Sample("toto");
         Response response = httpClient.url(rootUrl()).xmlPost(r).get();
-        r = (Sample)response.getResource(r.getClass());
+        r = (Sample)response.resource(r.getClass());
         Assertions.assertThat(r).isNotNull();
         Assertions.assertThat(r.getName()).isEqualTo("toto");
     }
@@ -58,7 +58,7 @@ public class XmlServiceBasedRestControllerWebTest extends AbstractWebTest {
     public void testDeleteResource() throws IllegalArgumentException, IOException, InterruptedException, ExecutionException {
         Client httpClient = new Client();
     	Sample r = new Sample("toto");
-        r = httpClient.url(rootUrl()).xmlPost(r).get().getResource(r.getClass());
+        r = httpClient.url(rootUrl()).xmlPost(r).get().resource(r.getClass());
         Assertions.assertThat(r).isNotNull();
 
         Response response = httpClient.url(rootUrl() + "/" + r.getId()).delete().get();
@@ -72,7 +72,7 @@ public class XmlServiceBasedRestControllerWebTest extends AbstractWebTest {
     public void testFindResource() throws IllegalArgumentException, IOException, InterruptedException, ExecutionException {
         Client httpClient = new Client();
         Sample r = new Sample("toto");
-        r = (Sample)httpClient.url(rootUrl()).xmlPost(r).get().getResource(r.getClass());
+        r = (Sample)httpClient.url(rootUrl()).xmlPost(r).get().resource(r.getClass());
         
         Response response = httpClient.url(rootUrl() + "/" + r.getId()).get().get();
         Assertions.assertThat(response.getStatus()).isEqualTo(Http.OK);
@@ -82,10 +82,10 @@ public class XmlServiceBasedRestControllerWebTest extends AbstractWebTest {
     public void testUpdate() throws IllegalArgumentException, IOException, InterruptedException, ExecutionException {
         Client httpClient = new Client();
         Sample r1 = new Sample("toto");
-        r1 = httpClient.url(rootUrl()).xmlPost(r1).get().getResource(r1.getClass());
+        r1 = httpClient.url(rootUrl()).xmlPost(r1).get().resource(r1.getClass());
         Sample r2 = new Sample(r1);
         r2.setName("titi");
-        r2 = httpClient.url(rootUrl() + "/" + r1.getId()).xmlPut(r2).get().getResource(r2.getClass());
+        r2 = httpClient.url(rootUrl() + "/" + r1.getId()).xmlPut(r2).get().resource(r2.getClass());
         Assertions.assertThat(r1).isNotEqualTo(r2);
         Assertions.assertThat(r1.getName()).contains("toto");
         Assertions.assertThat(r2.getName()).contains("titi");

--- a/resthub-web/resthub-web-server/src/test/java/org/resthub/web/controller/XmlServiceBasedRestControllerWebTest.java
+++ b/resthub-web/resthub-web-server/src/test/java/org/resthub/web/controller/XmlServiceBasedRestControllerWebTest.java
@@ -31,7 +31,7 @@ public class XmlServiceBasedRestControllerWebTest extends AbstractWebTest {
         Client httpClient = new Client();
         Sample r = new Sample("toto");
         Response response = httpClient.url(rootUrl()).xmlPost(r).get();
-        r = (Sample)response.getEntity(r.getClass());
+        r = (Sample)response.getResource(r.getClass());
         Assertions.assertThat(r).isNotNull();
         Assertions.assertThat(r.getName()).isEqualTo("toto");
     }
@@ -58,7 +58,7 @@ public class XmlServiceBasedRestControllerWebTest extends AbstractWebTest {
     public void testDeleteResource() throws IllegalArgumentException, IOException, InterruptedException, ExecutionException {
         Client httpClient = new Client();
     	Sample r = new Sample("toto");
-        r = httpClient.url(rootUrl()).xmlPost(r).get().getEntity(r.getClass());
+        r = httpClient.url(rootUrl()).xmlPost(r).get().getResource(r.getClass());
         Assertions.assertThat(r).isNotNull();
 
         Response response = httpClient.url(rootUrl() + "/" + r.getId()).delete().get();
@@ -72,7 +72,7 @@ public class XmlServiceBasedRestControllerWebTest extends AbstractWebTest {
     public void testFindResource() throws IllegalArgumentException, IOException, InterruptedException, ExecutionException {
         Client httpClient = new Client();
         Sample r = new Sample("toto");
-        r = (Sample)httpClient.url(rootUrl()).xmlPost(r).get().getEntity(r.getClass());
+        r = (Sample)httpClient.url(rootUrl()).xmlPost(r).get().getResource(r.getClass());
         
         Response response = httpClient.url(rootUrl() + "/" + r.getId()).get().get();
         Assertions.assertThat(response.getStatus()).isEqualTo(Http.OK);
@@ -82,10 +82,10 @@ public class XmlServiceBasedRestControllerWebTest extends AbstractWebTest {
     public void testUpdate() throws IllegalArgumentException, IOException, InterruptedException, ExecutionException {
         Client httpClient = new Client();
         Sample r1 = new Sample("toto");
-        r1 = httpClient.url(rootUrl()).xmlPost(r1).get().getEntity(r1.getClass());
+        r1 = httpClient.url(rootUrl()).xmlPost(r1).get().getResource(r1.getClass());
         Sample r2 = new Sample(r1);
         r2.setName("titi");
-        r2 = httpClient.url(rootUrl() + "/" + r1.getId()).xmlPut(r2).get().getEntity(r2.getClass());
+        r2 = httpClient.url(rootUrl() + "/" + r1.getId()).xmlPut(r2).get().getResource(r2.getClass());
         Assertions.assertThat(r1).isNotEqualTo(r2);
         Assertions.assertThat(r1.getName()).contains("toto");
         Assertions.assertThat(r2.getName()).contains("titi");

--- a/resthub-web/resthub-web-server/src/test/java/org/resthub/web/controller/XmlServiceBasedRestControllerWebTest.java
+++ b/resthub-web/resthub-web-server/src/test/java/org/resthub/web/controller/XmlServiceBasedRestControllerWebTest.java
@@ -6,6 +6,7 @@ import org.fest.assertions.api.Assertions;
 import org.resthub.test.common.AbstractWebTest;
 import org.resthub.web.Client;
 import org.resthub.web.Http;
+import org.resthub.web.Response;
 import org.resthub.web.model.Sample;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Test;
@@ -29,8 +30,8 @@ public class XmlServiceBasedRestControllerWebTest extends AbstractWebTest {
     public void testCreateResource() throws IllegalArgumentException, InterruptedException, ExecutionException, IOException {
         Client httpClient = new Client();
         Sample r = new Sample("toto");
-        Client.Response response = httpClient.url(rootUrl()).xmlPost(r).get();
-        r = (Sample)response.xmlDeserialize(r.getClass());
+        Response response = httpClient.url(rootUrl()).xmlPost(r).get();
+        r = (Sample)response.getEntity(r.getClass());
         Assertions.assertThat(r).isNotNull();
         Assertions.assertThat(r.getName()).isEqualTo("toto");
     }
@@ -57,10 +58,10 @@ public class XmlServiceBasedRestControllerWebTest extends AbstractWebTest {
     public void testDeleteResource() throws IllegalArgumentException, IOException, InterruptedException, ExecutionException {
         Client httpClient = new Client();
     	Sample r = new Sample("toto");
-        r = httpClient.url(rootUrl()).xmlPost(r).get().xmlDeserialize(r.getClass());
+        r = httpClient.url(rootUrl()).xmlPost(r).get().getEntity(r.getClass());
         Assertions.assertThat(r).isNotNull();
 
-        Client.Response response = httpClient.url(rootUrl() + "/" + r.getId()).delete().get();
+        Response response = httpClient.url(rootUrl() + "/" + r.getId()).delete().get();
         Assertions.assertThat(response.getStatus()).isEqualTo(Http.NO_CONTENT);
        
         response = httpClient.url(rootUrl() + "/" + r.getId()).get().get();
@@ -71,9 +72,9 @@ public class XmlServiceBasedRestControllerWebTest extends AbstractWebTest {
     public void testFindResource() throws IllegalArgumentException, IOException, InterruptedException, ExecutionException {
         Client httpClient = new Client();
         Sample r = new Sample("toto");
-        r = (Sample)httpClient.url(rootUrl()).xmlPost(r).get().xmlDeserialize(r.getClass());
+        r = (Sample)httpClient.url(rootUrl()).xmlPost(r).get().getEntity(r.getClass());
         
-        Client.Response response = httpClient.url(rootUrl() + "/" + r.getId()).get().get();
+        Response response = httpClient.url(rootUrl() + "/" + r.getId()).get().get();
         Assertions.assertThat(response.getStatus()).isEqualTo(Http.OK);
     }
 
@@ -81,10 +82,10 @@ public class XmlServiceBasedRestControllerWebTest extends AbstractWebTest {
     public void testUpdate() throws IllegalArgumentException, IOException, InterruptedException, ExecutionException {
         Client httpClient = new Client();
         Sample r1 = new Sample("toto");
-        r1 = httpClient.url(rootUrl()).xmlPost(r1).get().xmlDeserialize(r1.getClass());
+        r1 = httpClient.url(rootUrl()).xmlPost(r1).get().getEntity(r1.getClass());
         Sample r2 = new Sample(r1);
         r2.setName("titi");
-        r2 = httpClient.url(rootUrl() + "/" + r1.getId()).xmlPut(r2).get().xmlDeserialize(r2.getClass());
+        r2 = httpClient.url(rootUrl() + "/" + r1.getId()).xmlPut(r2).get().getEntity(r2.getClass());
         Assertions.assertThat(r1).isNotEqualTo(r2);
         Assertions.assertThat(r1.getName()).contains("toto");
         Assertions.assertThat(r2.getName()).contains("titi");


### PR DESCRIPTION
When dealing with async HTTP, request/response code can be far appart and decoupled.
For me, using an API like Client.Response.jsonDeserialize can be awkward, since you may not know which content-type was used when the request was sent.
### Introducing BodyReaders and BodyWriters

I know, it is JAX-RS like, but this is quite useful.
RESThub's HTTP client supports JSON and XML out-of-the-box. Users can add other BodyWriters/BodyReaders to support other mediaTypes.
### API changes

**Response is no longer an inner class**

``` java
import org.resthub.web.Client.Response;
```

is now:

``` java
import org.resthub.web.Response;
```

**You don't need to specify the response format to deserialize it**

``` java
future.get().jsonDeserialize(User.class);
```

is now:

``` java
future.get().getEntity(User.class);
```
### Bugs fixed

JSON BodyReader matches standard json and vendor content-types

> application/json
> application/vnd.atos.v2+json

XMLBodyReader matches standard xml and vendor content-types

> application/xml
> application/vnd.atos.v2+xml
