### PR TITLE
OAuth2.0 fix

### DIFF
--- a/resthub-web/resthub-web-client/pom.xml
+++ b/resthub-web/resthub-web-client/pom.xml
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.springframework.security.oauth</groupId>
             <artifactId>spring-security-oauth2</artifactId>
-            <version>1.0.0.M6</version>
+            <version>1.0.0.RC1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/resthub-web/resthub-web-client/src/main/java/org/resthub/web/Client.java
+++ b/resthub-web/resthub-web-client/src/main/java/org/resthub/web/Client.java
@@ -1,24 +1,24 @@
 package org.resthub.web;
 
+import com.ning.http.client.*;
 import com.ning.http.client.AsyncHttpClientConfig.Builder;
 import com.ning.http.client.Realm.AuthScheme;
 import com.ning.http.client.Realm.RealmBuilder;
-import com.ning.http.client.*;
 import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.*;
 import java.util.concurrent.Future;
+import org.resthub.web.Response;
 import org.resthub.web.oauth2.OAuth2RequestFilter;
 import org.resthub.web.support.*;
 
 /**
  * RESThub AsyncHttpClient wrapper inspired from Play Framework 2 one
  *
- * Sample usage : User user =
- * Client.url("http://localhost:8080/api/user".jsonPost(user).get().getEntity(User.class);
- *
+ * Sample usage : Client httpClient = new Client(); User user =
+ * httpClient.url("http://localhost:8080/api/user".jsonPost(user).get().resource(User.class);
  *
  */
 public class Client implements Closeable {
@@ -32,6 +32,7 @@ public class Client implements Closeable {
     private String clientId = null;
     private String clientSecret = null;
     private String accessTokenEndpoint = null;
+    private String oauth2_scheme = null;
     private AuthScheme scheme = null;
 
     public Client() {
@@ -58,7 +59,7 @@ public class Client implements Closeable {
     }
 
     /**
-     * Sets the authentication header for the current request.
+     * Sets the authentication header for the current client.
      *
      * @param username
      * @param password
@@ -72,13 +73,35 @@ public class Client implements Closeable {
     }
 
     /**
-     * Sets the OAuth2 authentication header for the current request.
+     * Sets the OAuth2 authentication header for the current client.
      *
-     * @param username
-     * @param password
-     * @param accessTokenEndpoint
-     * @param clientId
-     * @param clientSecret
+     * @param username The user's login
+     * @param password The user's password
+     * @param accessTokenEndpoint URL of the OAuth2.0 access token endpoint
+     * service
+     * @param clientId id of the current application registered with the remote
+     * OAuth2.0 provider
+     * @param clientSecret secret of the current application registered with the
+     * remote OAuth2.0 provider
+     * @param oauth2_scheme scheme used by OAuth2.0 requests when sending tokens
+     * (default: 'Bearer')
+     */
+    public Client setOAuth2(String username, String password, String accessTokenEndpoint, String clientId, String clientSecret, String oauth2_scheme) {
+        this.oauth2_scheme = oauth2_scheme;
+        return this.setOAuth2(username, password, accessTokenEndpoint, clientId, clientSecret);
+    }
+
+    /**
+     * Sets the OAuth2 authentication header for the current client.
+     *
+     * @param username The user's login
+     * @param password The user's password
+     * @param accessTokenEndpoint URL of the OAuth2.0 access token endpoint
+     * service
+     * @param clientId id of the current application registered with the remote
+     * OAuth2.0 provider
+     * @param clientSecret secret of the current application registered with the
+     * remote OAuth2.0 provider
      */
     public Client setOAuth2(String username, String password, String accessTokenEndpoint, String clientId, String clientSecret) {
         this.username = username;
@@ -86,7 +109,6 @@ public class Client implements Closeable {
         this.accessTokenEndpoint = accessTokenEndpoint;
         this.clientId = clientId;
         this.clientSecret = clientSecret;
-        builder.addRequestFilter(new OAuth2RequestFilter(accessTokenEndpoint, clientId, clientSecret));
         return this;
     }
 
@@ -97,7 +119,7 @@ public class Client implements Closeable {
      */
     public RequestHolder url(String url) {
         if (this.client == null) {
-            this.client = new AsyncHttpClient(builder.build());
+            this.client = buildClient();
         }
 
         this.bodyReaders.add(new JsonBodyReader());
@@ -113,6 +135,20 @@ public class Client implements Closeable {
         if (client != null) {
             client.close();
         }
+    }
+
+    private AsyncHttpClient buildClient() {
+
+        if (accessTokenEndpoint != null && clientId != null && clientSecret != null && username != null && password != null) {
+
+            OAuth2RequestFilter oauth2Filter = new OAuth2RequestFilter(accessTokenEndpoint, clientId, clientSecret);
+            if (oauth2_scheme != null) {
+                oauth2Filter.setScheme_name(oauth2_scheme);
+            }
+            builder.addRequestFilter(oauth2Filter);
+        }
+
+        return new AsyncHttpClient(builder.build());
     }
 
     /**
@@ -292,7 +328,7 @@ public class Client implements Closeable {
         public Future<Response> put(File body) {
             return executeFile("PUT", body);
         }
-        
+
         /**
          * Perform a DELETE on the request asynchronously.
          */
@@ -352,11 +388,11 @@ public class Client implements Closeable {
         private String serialize(String mediaType, Object o) {
 
             for (BodyWriter bw : bodyWriters) {
-                if(bw.canWrite(mediaType)) {
+                if (bw.canWrite(mediaType)) {
                     return bw.writeEntity(mediaType, o);
                 }
             }
-            throw new RuntimeException("cannot serialize request body for mediaType "+mediaType);
+            throw new RuntimeException("cannot serialize request body for mediaType " + mediaType);
         }
     }
 }

--- a/resthub-web/resthub-web-client/src/main/java/org/resthub/web/Client.java
+++ b/resthub-web/resthub-web-client/src/main/java/org/resthub/web/Client.java
@@ -143,7 +143,7 @@ public class Client implements Closeable {
 
             OAuth2RequestFilter oauth2Filter = new OAuth2RequestFilter(accessTokenEndpoint, clientId, clientSecret);
             if (oauth2_scheme != null) {
-                oauth2Filter.setScheme_name(oauth2_scheme);
+                oauth2Filter.setSchemeName(oauth2_scheme);
             }
             builder.addRequestFilter(oauth2Filter);
         }

--- a/resthub-web/resthub-web-client/src/main/java/org/resthub/web/oauth2/OAuth2RequestFilter.java
+++ b/resthub-web/resthub-web-client/src/main/java/org/resthub/web/oauth2/OAuth2RequestFilter.java
@@ -18,7 +18,6 @@ import java.util.concurrent.ExecutionException;
  */
 public class OAuth2RequestFilter implements RequestFilter {
 
-    public static final String SCHEME_NAME = "Bearer";
     public static final String GRANT_TYPE_PARAMETER_NAME = "grant_type";
     public static final String CLIENT_ID_PARAMETER_NAME = "client_id";
     public static final String CLIENT_SECRET_PARAMETER_NAME = "client_secret";
@@ -30,6 +29,7 @@ public class OAuth2RequestFilter implements RequestFilter {
     protected String accessTokenEndPoint;
     protected String clientId;
     protected String clientSecret;
+    protected String scheme_name = "Bearer";
 
     protected OAuth2Token token;
 
@@ -65,6 +65,14 @@ public class OAuth2RequestFilter implements RequestFilter {
         this.clientSecret = clientSecret;
     }
 
+    public String getScheme_name() {
+        return scheme_name;
+    }
+
+    public void setScheme_name(String scheme_name) {
+        this.scheme_name = scheme_name;
+    }
+
     private OAuth2Token retrieveAccessToken(String username, String password) {
         AsyncHttpClient client = new AsyncHttpClient();
         BoundRequestBuilder request = client.preparePost(this.accessTokenEndPoint);
@@ -97,7 +105,7 @@ public class OAuth2RequestFilter implements RequestFilter {
                     .getPassword());
         }
 
-        ctx.getRequest().getHeaders().add(Http.AUTHORIZATION, SCHEME_NAME + " " + token.getAccessToken());
+        ctx.getRequest().getHeaders().add(Http.AUTHORIZATION, scheme_name + " " + token.getAccessToken());
         return ctx;
     }
 }

--- a/resthub-web/resthub-web-client/src/main/java/org/resthub/web/oauth2/OAuth2RequestFilter.java
+++ b/resthub-web/resthub-web-client/src/main/java/org/resthub/web/oauth2/OAuth2RequestFilter.java
@@ -77,11 +77,11 @@ public class OAuth2RequestFilter implements RequestFilter {
         this.clientSecret = clientSecret;
     }
 
-    public String getScheme_name() {
+    public String getSchemeName() {
         return scheme_name;
     }
 
-    public void setScheme_name(String scheme_name) {
+    public void setSchemeName(String scheme_name) {
         this.scheme_name = scheme_name;
     }
 

--- a/resthub-web/resthub-web-client/src/test/java/org/resthub/web/oauth2/TestOAuth2Client.java
+++ b/resthub-web/resthub-web-client/src/test/java/org/resthub/web/oauth2/TestOAuth2Client.java
@@ -29,6 +29,7 @@ import com.ning.http.client.AsyncHttpClientConfig.Builder;
  * <li>a resource service protected with resthub-oauth2-filter.</li>
  * </ol>
  */
+// TODO: refactor those tests - use mocks and avoid Thread.sleep
 public class TestOAuth2Client {
 
     public static final String CLIENT_ID = "test";
@@ -92,5 +93,19 @@ public class TestOAuth2Client {
     public void testUnauthorizeRequest() throws IOException, InterruptedException, ExecutionException {
     	Response response = new Client().url(BASE_URL + "/api/resource/hello").getJson().get();
     	Assertions.assertThat(response.getStatus()).isEqualTo(Http.UNAUTHORIZED);
+    }
+    
+    @Test
+    public void testTokenExpired() throws IOException, InterruptedException, ExecutionException {
+        Client client = new Client().setOAuth2("test", "t3st", ACCESS_TOKEN_ENDPOINT, CLIENT_ID, CLIENT_SECRET); 
+        String result = client.url(BASE_URL + "/api/resource/hello").get().get().getBody();
+        Assertions.assertThat(result).isEqualTo("Hello");
+        
+        // wait for the token to expire
+        Thread.sleep(1000L);
+        
+        // the client should detect its token is expired and ask for a new token
+        result = client.url(BASE_URL + "/api/resource/hello").get().get().getBody();
+        Assertions.assertThat(result).isEqualTo("Hello");
     }
 }

--- a/resthub-web/resthub-web-client/src/test/resources/applicationContext.xml
+++ b/resthub-web/resthub-web-client/src/test/resources/applicationContext.xml
@@ -35,13 +35,13 @@
         <security:custom-filter ref="clientCredentialsTokenEndpointFilter" before="BASIC_AUTH_FILTER" />
     </security:http>
 
-    <bean id="clientCredentialsTokenEndpointFilter" class="org.springframework.security.oauth2.provider.filter.ClientCredentialsTokenEndpointFilter">
+    <bean id="clientCredentialsTokenEndpointFilter" class="org.springframework.security.oauth2.provider.client.ClientCredentialsTokenEndpointFilter">
         <property name="authenticationManager" ref="clientAuthenticationManager" />
     </bean>
 
     <mvc:annotation-driven />
 
-    <bean id="entryPoint" class="org.springframework.security.oauth2.provider.error.MediaTypeAwareAuthenticationEntryPoint">
+    <bean id="entryPoint" class="org.springframework.security.oauth2.provider.error.OAuth2AuthenticationEntryPoint">
         <property name="realmName" value="test" />
     </bean>
 
@@ -59,11 +59,12 @@
 
     <bean id="oauth2AccessDeniedHandler" class="org.springframework.security.web.access.AccessDeniedHandlerImpl" />
 
-    <bean id="tokenServices" class="org.springframework.security.oauth2.provider.token.RandomValueTokenServices">
+    <bean id="tokenServices" class="org.springframework.security.oauth2.provider.token.DefaultTokenServices">
         <property name="tokenStore">
             <bean class="org.springframework.security.oauth2.provider.token.InMemoryTokenStore" />
         </property>
         <property name="supportRefreshToken" value="false" />
+        <property name="accessTokenValiditySeconds" value="2" />
     </bean>
 
     <oauth2:authorization-server client-details-service-ref="clientDetails" token-services-ref="tokenServices">


### PR DESCRIPTION
Allow users to redefine OAuth2.0 token header key sent along resource requests.
Default value is "Bearer".

Implement auto-renewal of the OAuth2.0 token when it's expired.
I didn't implement this as a ResponseFilter because:
- RequestFilter and ResponseFilters are totally decoupled (so you can't modify the token store within the RequestFilter from the ResponseFilter)
- You can actuall receive HTTP Unauthorized responses for a lot of reasons (not only an expired token), and messing with the response can be an unpleasant surprise for RESThub's users
- A ResponseFilter can replay a request, but not issue a request AND replay the last request

Don't merge this pull request now. I'll probably modify it, I'm waiting for feedback on that matter.
