### PR TITLE
Fix issue #109 and add sync/async methods in HTTP Client

### DIFF
--- a/resthub-web/resthub-web-client/src/test/java/org/resthub/web/ClientTest.java
+++ b/resthub-web/resthub-web-client/src/test/java/org/resthub/web/ClientTest.java
@@ -1,0 +1,15 @@
+package org.resthub.web;
+
+import org.testng.annotations.Test;
+
+/**
+ * Test the HTTP Client
+ */
+public class ClientTest {
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testCreateClientWithQueryParamsInUrl() {
+        Client client = new Client();
+        client.url("http://example.org/resource?qparam=shouldfail");
+    }
+}

--- a/resthub-web/resthub-web-client/src/test/java/org/resthub/web/oauth2/TestOAuth2Client.java
+++ b/resthub-web/resthub-web-client/src/test/java/org/resthub/web/oauth2/TestOAuth2Client.java
@@ -14,6 +14,8 @@ import org.fest.assertions.api.Assertions;
 import org.resthub.web.Client;
 import org.resthub.web.Response;
 import org.resthub.web.Http;
+import org.resthub.web.exception.HttpException;
+import org.resthub.web.exception.UnauthorizedException;
 import org.springframework.web.filter.DelegatingFilterProxy;
 import org.springframework.web.servlet.DispatcherServlet;
 import org.testng.annotations.AfterTest;
@@ -85,29 +87,28 @@ public class TestOAuth2Client {
     }
 
     @Test
-    public void testOAuth2SuccessfulRequest() throws IOException, InterruptedException, ExecutionException {
+    public void testOAuth2SuccessfulRequest() {
         Client client = new Client().setOAuth2("test", "t3st", ACCESS_TOKEN_ENDPOINT, CLIENT_ID, CLIENT_SECRET);
-        String result = client.url(BASE_URL + "/api/resource/hello").get().get().getBody();
+        String result = client.url(BASE_URL + "/api/resource/hello").get().getBody();
         Assertions.assertThat(result).isEqualTo("Hello");
     }
 
-    @Test
-    public void testUnauthorizeRequest() throws IOException, InterruptedException, ExecutionException {
-        Response response = new Client().url(BASE_URL + "/api/resource/hello").getJson().get();
-        Assertions.assertThat(response.getStatus()).isEqualTo(Http.UNAUTHORIZED);
+    @Test(expectedExceptions = {UnauthorizedException.class})
+    public void testUnauthorizeRequest() {
+        Response response = new Client().url(BASE_URL + "/api/resource/hello").getJson();
     }
 
     @Test
-    public void testTokenExpired() throws IOException, InterruptedException, ExecutionException {
+    public void testTokenExpired() throws InterruptedException {
         Client client = new Client().setOAuth2("test", "t3st", ACCESS_TOKEN_ENDPOINT, CLIENT_ID, CLIENT_SECRET);
-        String result = client.url(BASE_URL + "/api/resource/hello").get().get().getBody();
+        String result = client.url(BASE_URL + "/api/resource/hello").get().getBody();
         Assertions.assertThat(result).isEqualTo("Hello");
 
         // wait for the token to expire
         Thread.sleep(1000L);
 
         // the client should detect its token is expired and ask for a new token
-        result = client.url(BASE_URL + "/api/resource/hello").get().get().getBody();
+        result = client.url(BASE_URL + "/api/resource/hello").get().getBody();
         Assertions.assertThat(result).isEqualTo("Hello");
     }
 }

--- a/resthub-web/resthub-web-server/src/test/java/org/resthub/web/controller/JsonRepositoryBasedRestControllerTest.java
+++ b/resthub-web/resthub-web-server/src/test/java/org/resthub/web/controller/JsonRepositoryBasedRestControllerTest.java
@@ -7,6 +7,9 @@ import org.resthub.test.common.AbstractWebTest;
 import org.resthub.web.Client;
 import org.resthub.web.Http;
 import org.resthub.web.Response;
+import org.resthub.web.exception.BadRequestException;
+import org.resthub.web.exception.InternalServerErrorException;
+import org.resthub.web.exception.NotFoundException;
 import org.resthub.web.model.Sample;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Test;
@@ -24,107 +27,98 @@ public class JsonRepositoryBasedRestControllerTest extends AbstractWebTest {
 
     @AfterMethod
     public void tearDown() {
-        try {
-            new Client().url(rootUrl()).delete().get();
-        } catch (InterruptedException | ExecutionException e) {
-            Assertions.fail("Exception during delete all request", e);
-        }
+            new Client().url(rootUrl()).delete();
     }
 
     @Test
-    public void testCreateResource() throws IllegalArgumentException, InterruptedException, ExecutionException,
-            IOException {
+    public void testCreateResource() {
         Sample r = new Sample("toto");
-        Response response = new Client().url(rootUrl()).jsonPost(r).get();
+        Response response = new Client().url(rootUrl()).jsonPost(r);
         r = (Sample) response.resource(r.getClass());
         Assertions.assertThat(r).isNotNull();
         Assertions.assertThat(r.getName()).isEqualTo("toto");
     }
 
     @Test
-    public void testFindAllResources() throws IllegalArgumentException, InterruptedException, ExecutionException,
-            IOException {
+    public void testFindAllResources() {
         Client httpClient = new Client();
-        httpClient.url(rootUrl()).jsonPost(new Sample("toto")).get();
-        httpClient.url(rootUrl()).jsonPost(new Sample("toto")).get();
-        String responseBody = httpClient.url(rootUrl()).getJson().get().getBody();
+        httpClient.url(rootUrl()).jsonPost(new Sample("toto"));
+        httpClient.url(rootUrl()).jsonPost(new Sample("toto"));
+        String responseBody = httpClient.url(rootUrl()).getJson().getBody();
         Assertions.assertThat(responseBody).contains("toto");
         Assertions.assertThat(responseBody).contains("\"totalElements\":2");
         Assertions.assertThat(responseBody).contains("\"numberOfElements\":2");
     }
     
     @Test
-    public void testFindAllResourcesUnpaginated() throws IllegalArgumentException, InterruptedException, ExecutionException,
-            IOException {
+    public void testFindAllResourcesUnpaginated() {
         Client httpClient = new Client();
-        httpClient.url(rootUrl()).jsonPost(new Sample("toto")).get();
-        httpClient.url(rootUrl()).jsonPost(new Sample("toto")).get();
-        String responseBody = httpClient.url(rootUrl()).setQueryParameter("page", "no").getJson().get().getBody();
+        httpClient.url(rootUrl()).jsonPost(new Sample("toto"));
+        httpClient.url(rootUrl()).jsonPost(new Sample("toto"));
+        String responseBody = httpClient.url(rootUrl()).setQueryParameter("page", "no").getJson().getBody();
         Assertions.assertThat(responseBody).contains("toto");
         Assertions.assertThat(responseBody).doesNotContain("\"totalElements\":2");
         Assertions.assertThat(responseBody).doesNotContain("\"numberOfElements\":2");
     }
 
     @Test
-    public void testFindPaginatedResources() throws IllegalArgumentException, InterruptedException, ExecutionException, IOException {
+    public void testFindPaginatedResources() {
         Client httpClient = new Client();
-        httpClient.url(rootUrl()).xmlPost(new Sample("toto")).get();
-        httpClient.url(rootUrl()).xmlPost(new Sample("toto")).get();
+        httpClient.url(rootUrl()).xmlPost(new Sample("toto"));
+        httpClient.url(rootUrl()).xmlPost(new Sample("toto"));
         String responseBody = httpClient.url(rootUrl()).setQueryParameter("page", "1")
-                .getJson().get().getBody();
+                .getJson().getBody();
         Assertions.assertThat(responseBody).contains("\"totalElements\":2");
         Assertions.assertThat(responseBody).contains("\"numberOfElements\":2");
         responseBody = httpClient.url(rootUrl()).setQueryParameter("page", "1")
-                .setQueryParameter("size", "1").getJson().get().getBody();
+                .setQueryParameter("size", "1").getJson().getBody();
         Assertions.assertThat(responseBody).contains("\"totalElements\":2");
         Assertions.assertThat(responseBody).contains("\"numberOfElements\":1");
     }
-    
-    @Test
-    public void testFindPaginatedResourcesReturnsBadRequestForAnInvalidPageNumber() throws InterruptedException, ExecutionException {
+
+    @Test(expectedExceptions = {InternalServerErrorException.class})
+    public void testFindPaginatedResourcesReturnsBadRequestForAnInvalidPageNumber() {
         Client httpClient = new Client();
-        httpClient.url(rootUrl()).xmlPost(new Sample("toto")).get();
-        httpClient.url(rootUrl()).xmlPost(new Sample("toto")).get();
+        httpClient.url(rootUrl()).xmlPost(new Sample("toto"));
+        httpClient.url(rootUrl()).xmlPost(new Sample("toto"));
         Response response = httpClient.url(rootUrl()).setQueryParameter("page", "0")
-                .getJson().get();
+                .getJson();
         // TODO: Map IllegalArgumentException to 400 Bad Request
         Assertions.assertThat(response.getStatus()).isEqualTo(500);
         Assertions.assertThat(response.getBody()).contains("Page index must be greater than 0");
     }
 
-    @Test
-    public void testDeleteResource() throws IllegalArgumentException, IOException, InterruptedException,
-            ExecutionException {
+    @Test(expectedExceptions = {NotFoundException.class})
+    public void testDeleteResource() {
         Client httpClient = new Client();
         Sample r = new Sample("toto");
-        r = httpClient.url(rootUrl()).jsonPost(r).get().resource(r.getClass());
+        r = httpClient.url(rootUrl()).jsonPost(r).resource(r.getClass());
         Assertions.assertThat(r).isNotNull();
 
-        Response response = httpClient.url(rootUrl() + "/" + r.getId()).delete().get();
+        Response response = httpClient.url(rootUrl() + "/" + r.getId()).delete();
         Assertions.assertThat(response.getStatus()).isEqualTo(Http.NO_CONTENT);
-        response = httpClient.url(rootUrl() + "/" + r.getId()).get().get();
+        response = httpClient.url(rootUrl() + "/" + r.getId()).get();
         Assertions.assertThat(response.getStatus()).isEqualTo(Http.NOT_FOUND);
     }
 
     @Test
-    public void testFindResource() throws IllegalArgumentException, IOException, InterruptedException,
-            ExecutionException {
+    public void testFindResource() {
         Client httpClient = new Client();
         Sample r = new Sample("toto");
-        r = httpClient.url(rootUrl()).jsonPost(r).get().resource(r.getClass());
+        r = httpClient.url(rootUrl()).jsonPost(r).resource(r.getClass());
 
-        Response response = httpClient.url(rootUrl() + "/" + r.getId()).get().get();
+        Response response = httpClient.url(rootUrl() + "/" + r.getId()).get();
         Assertions.assertThat(response.getStatus()).isEqualTo(Http.OK);
     }
 
     @Test
-    public void testUpdate() throws IllegalArgumentException, IOException, InterruptedException, ExecutionException {
+    public void testUpdate() {
         Client httpClient = new Client();
         Sample r1 = new Sample("toto");
-        r1 = httpClient.url(rootUrl()).jsonPost(r1).get().resource(r1.getClass());
+        r1 = httpClient.url(rootUrl()).jsonPost(r1).resource(r1.getClass());
         Sample r2 = new Sample(r1);
         r2.setName("titi");
-        r2 = httpClient.url(rootUrl() + "/" + r1.getId()).jsonPut(r2).get().resource(r2.getClass());
+        r2 = httpClient.url(rootUrl() + "/" + r1.getId()).jsonPut(r2).resource(r2.getClass());
         Assertions.assertThat(r1).isNotEqualTo(r2);
         Assertions.assertThat(r1.getName()).contains("toto");
         Assertions.assertThat(r2.getName()).contains("titi");

--- a/resthub-web/resthub-web-server/src/test/java/org/resthub/web/controller/JsonServiceBasedRestControllerTest.java
+++ b/resthub-web/resthub-web-server/src/test/java/org/resthub/web/controller/JsonServiceBasedRestControllerTest.java
@@ -8,6 +8,8 @@ import org.resthub.test.common.AbstractWebTest;
 import org.resthub.web.Client;
 import org.resthub.web.Http;
 import org.resthub.web.Response;
+import org.resthub.web.exception.HttpServerErrorException;
+import org.resthub.web.exception.NotFoundException;
 import org.resthub.web.model.Sample;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Test;
@@ -24,109 +26,100 @@ public class JsonServiceBasedRestControllerTest extends AbstractWebTest {
 
     @AfterMethod
     public void tearDown() {
-        try {
-            new Client().url(rootUrl()).delete().get();
-        } catch (InterruptedException | ExecutionException e) {
-            Assertions.fail("Exception during delete all request", e);
-        }
+            new Client().url(rootUrl()).delete();
     }
 
     @Test
-    public void testCreateResource() throws IllegalArgumentException, InterruptedException, ExecutionException,
-            IOException {
+    public void testCreateResource() {
         Client httpClient = new Client();
         Sample r = new Sample("toto");
-        Response response = httpClient.url(rootUrl()).jsonPost(r).get();
+        Response response = httpClient.url(rootUrl()).jsonPost(r);
         r = (Sample) response.resource(r.getClass());
         Assertions.assertThat(r).isNotNull();
         Assertions.assertThat(r.getName()).isEqualTo("toto");
     }
 
     @Test
-    public void testFindAllResources() throws IllegalArgumentException, InterruptedException, ExecutionException,
-            IOException {
+    public void testFindAllResources() {
         Client httpClient = new Client();
-        httpClient.url(rootUrl()).jsonPost(new Sample("toto")).get();
-        httpClient.url(rootUrl()).jsonPost(new Sample("toto")).get();
-        String responseBody = httpClient.url(rootUrl()).getJson().get().getBody();
+        httpClient.url(rootUrl()).jsonPost(new Sample("toto"));
+        httpClient.url(rootUrl()).jsonPost(new Sample("toto"));
+        String responseBody = httpClient.url(rootUrl()).getJson().getBody();
         Assertions.assertThat(responseBody).contains("toto");
         Assertions.assertThat(responseBody).contains("\"totalElements\":2");
         Assertions.assertThat(responseBody).contains("\"numberOfElements\":2");
     }
     
     @Test
-    public void testFindAllResourcesUnpaginated() throws IllegalArgumentException, InterruptedException, ExecutionException,
-            IOException {
+    public void testFindAllResourcesUnpaginated() {
         Client httpClient = new Client();
-        httpClient.url(rootUrl()).jsonPost(new Sample("toto")).get();
-        httpClient.url(rootUrl()).jsonPost(new Sample("toto")).get();
-        String responseBody = httpClient.url(rootUrl()).setQueryParameter("page", "no").getJson().get().getBody();
+        httpClient.url(rootUrl()).jsonPost(new Sample("toto"));
+        httpClient.url(rootUrl()).jsonPost(new Sample("toto"));
+        String responseBody = httpClient.url(rootUrl()).setQueryParameter("page", "no").getJson().getBody();
         Assertions.assertThat(responseBody).contains("toto");
         Assertions.assertThat(responseBody).doesNotContain("\"totalElements\":2");
         Assertions.assertThat(responseBody).doesNotContain("\"numberOfElements\":2");
     }
 
     @Test
-    public void testFindPaginatedResources() throws IllegalArgumentException, InterruptedException, ExecutionException, IOException {
+    public void testFindPaginatedResources() {
         Client httpClient = new Client();
-        httpClient.url(rootUrl()).xmlPost(new Sample("toto")).get();
-        httpClient.url(rootUrl()).xmlPost(new Sample("toto")).get();
+        httpClient.url(rootUrl()).xmlPost(new Sample("toto"));
+        httpClient.url(rootUrl()).xmlPost(new Sample("toto"));
         String responseBody = httpClient.url(rootUrl()).setQueryParameter("page", "1")
-                .getJson().get().getBody();
+                .getJson().getBody();
         Assertions.assertThat(responseBody).contains("\"totalElements\":2");
         Assertions.assertThat(responseBody).contains("\"numberOfElements\":2");
         responseBody = httpClient.url(rootUrl()).setQueryParameter("page", "1")
-                .setQueryParameter("size", "1").getJson().get().getBody();
+                .setQueryParameter("size", "1").getJson().getBody();
         Assertions.assertThat(responseBody).contains("\"totalElements\":2");
         Assertions.assertThat(responseBody).contains("\"numberOfElements\":1");
     }
-    
-    @Test
-    public void testFindPaginatedResourcesReturnsBadRequestForAnInvalidPageNumber() throws InterruptedException, ExecutionException {
+
+    @Test(expectedExceptions = {HttpServerErrorException.class})
+    public void testFindPaginatedResourcesReturnsBadRequestForAnInvalidPageNumber() {
         Client httpClient = new Client();
-        httpClient.url(rootUrl()).xmlPost(new Sample("toto")).get();
-        httpClient.url(rootUrl()).xmlPost(new Sample("toto")).get();
+        httpClient.url(rootUrl()).xmlPost(new Sample("toto"));
+        httpClient.url(rootUrl()).xmlPost(new Sample("toto"));
         Response response = httpClient.url(rootUrl()).setQueryParameter("page", "0")
-                .getJson().get();
+                .getJson();
         // TODO: Map IllegalArgumentException to 400 Bad Request
         Assertions.assertThat(response.getStatus()).isEqualTo(500);
         Assertions.assertThat(response.getBody()).contains("Page index must be greater than 0");
     }
 
-    @Test
-    public void testDeleteResource() throws IllegalArgumentException, IOException, InterruptedException,
-            ExecutionException {
+    @Test(expectedExceptions = {NotFoundException.class})
+    public void testDeleteResource() {
         Client httpClient = new Client();
         Sample r = new Sample("toto");
-        r = httpClient.url(rootUrl()).jsonPost(r).get().resource(r.getClass());
+        r = httpClient.url(rootUrl()).jsonPost(r).resource(r.getClass());
         Assertions.assertThat(r).isNotNull();
 
-        Response response = httpClient.url(rootUrl() + "/" + r.getId()).delete().get();
+        Response response = httpClient.url(rootUrl() + "/" + r.getId()).delete();
         Assertions.assertThat(response.getStatus()).isEqualTo(Http.NO_CONTENT);
 
-        response = httpClient.url(rootUrl() + "/" + r.getId()).get().get();
+        response = httpClient.url(rootUrl() + "/" + r.getId()).get();
         Assertions.assertThat(response.getStatus()).isEqualTo(Http.NOT_FOUND);
     }
 
     @Test
-    public void testFindResource() throws IllegalArgumentException, IOException, InterruptedException,
-            ExecutionException {
+    public void testFindResource() {
         Client httpClient = new Client();
         Sample r = new Sample("toto");
-        r = httpClient.url(rootUrl()).jsonPost(r).get().resource(r.getClass());
+        r = httpClient.url(rootUrl()).jsonPost(r).resource(r.getClass());
 
-        Response response = httpClient.url(rootUrl() + "/" + r.getId()).get().get();
+        Response response = httpClient.url(rootUrl() + "/" + r.getId()).get();
         Assertions.assertThat(response.getStatus()).isEqualTo(Http.OK);
     }
 
     @Test
-    public void testUpdate() throws IllegalArgumentException, IOException, InterruptedException, ExecutionException {
+    public void testUpdate() {
         Client httpClient = new Client();
         Sample r1 = new Sample("toto");
-        r1 = httpClient.url(rootUrl()).jsonPost(r1).get().resource(r1.getClass());
+        r1 = httpClient.url(rootUrl()).jsonPost(r1).resource(r1.getClass());
         Sample r2 = new Sample(r1);
         r2.setName("titi");
-        r2 = httpClient.url(rootUrl() + "/" + r1.getId()).jsonPut(r2).get().resource(r2.getClass());
+        r2 = httpClient.url(rootUrl() + "/" + r1.getId()).jsonPut(r2).resource(r2.getClass());
         Assertions.assertThat(r1).isNotEqualTo(r2);
         Assertions.assertThat(r1.getName()).contains("toto");
         Assertions.assertThat(r2.getName()).contains("titi");

--- a/resthub-web/resthub-web-server/src/test/java/org/resthub/web/controller/XmlRepositoryBasedRestControllerWebTest.java
+++ b/resthub-web/resthub-web-server/src/test/java/org/resthub/web/controller/XmlRepositoryBasedRestControllerWebTest.java
@@ -8,6 +8,9 @@ import org.resthub.test.common.AbstractWebTest;
 import org.resthub.web.Client;
 import org.resthub.web.Http;
 import org.resthub.web.Response;
+import org.resthub.web.exception.HttpServerErrorException;
+import org.resthub.web.exception.NotFoundException;
+import org.resthub.web.exception.NotImplementedException;
 import org.resthub.web.model.Sample;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Test;
@@ -24,110 +27,100 @@ public class XmlRepositoryBasedRestControllerWebTest extends AbstractWebTest {
 
     @AfterMethod
     public void tearDown() {
-        try {
-            new Client().url(rootUrl()).delete().get();
-        } catch (InterruptedException | ExecutionException e) {
-            Assertions.fail("Exception during delete all request", e);
-        }
+            new Client().url(rootUrl()).delete();
     }
 
     @Test
-    public void testCreateResource() throws IllegalArgumentException, InterruptedException, ExecutionException,
-            IOException {
+    public void testCreateResource() {
         Client httpClient = new Client();
         Sample r = new Sample("toto");
-        Response response = httpClient.url(rootUrl()).xmlPost(r).get();
+        Response response = httpClient.url(rootUrl()).xmlPost(r);
         r = (Sample) response.resource(r.getClass());
         Assertions.assertThat(r).isNotNull();
         Assertions.assertThat(r.getName()).isEqualTo("toto");
     }
     
     @Test
-    public void testFindAllResources() throws IllegalArgumentException, InterruptedException, ExecutionException,
-            IOException {
+    public void testFindAllResources() {
         Client httpClient = new Client();
-        httpClient.url(rootUrl()).jsonPost(new Sample("toto")).get();
-        httpClient.url(rootUrl()).jsonPost(new Sample("toto")).get();
-        String responseBody = httpClient.url(rootUrl()).getXml().get().getBody();
+        httpClient.url(rootUrl()).jsonPost(new Sample("toto"));
+        httpClient.url(rootUrl()).jsonPost(new Sample("toto"));
+        String responseBody = httpClient.url(rootUrl()).getXml().getBody();
         Assertions.assertThat(responseBody).contains("toto");
         Assertions.assertThat(responseBody).contains("<totalElements>2</totalElements>");
         Assertions.assertThat(responseBody).contains("<numberOfElements>2</numberOfElements>");
     }
-   
-    @Test
-    public void testFindAllResourcesUnpaginated() throws IllegalArgumentException, InterruptedException, ExecutionException,
-            IOException {
+
+    @Test(expectedExceptions = {NotImplementedException.class})
+    public void testFindAllResourcesUnpaginated() {
         Client httpClient = new Client();
-        httpClient.url(rootUrl()).jsonPost(new Sample("toto")).get();
-        httpClient.url(rootUrl()).jsonPost(new Sample("toto")).get();
-        Response r = httpClient.url(rootUrl()).setQueryParameter("page", "no").getXml().get();
+        httpClient.url(rootUrl()).jsonPost(new Sample("toto"));
+        httpClient.url(rootUrl()).jsonPost(new Sample("toto"));
+        Response r = httpClient.url(rootUrl()).setQueryParameter("page", "no").getXml();
         Assertions.assertThat(r).isNotNull();
         Assertions.assertThat(r.getStatus()).isEqualTo(Http.NOT_IMPLEMENTED);
     }
 
 
     @Test
-    public void testFindPaginatedResources() throws IllegalArgumentException, InterruptedException,
-            ExecutionException, IOException {
+    public void testFindPaginatedResources() {
         Client httpClient = new Client();
-        httpClient.url(rootUrl()).xmlPost(new Sample("toto")).get();
-        httpClient.url(rootUrl()).xmlPost(new Sample("toto")).get();
-        String responseBody = httpClient.url(rootUrl()).setQueryParameter("page", "1").getXml().get()
+        httpClient.url(rootUrl()).xmlPost(new Sample("toto"));
+        httpClient.url(rootUrl()).xmlPost(new Sample("toto"));
+        String responseBody = httpClient.url(rootUrl()).setQueryParameter("page", "1").getXml()
                 .getBody();
         Assertions.assertThat(responseBody).contains("<totalElements>2</totalElements>");
         Assertions.assertThat(responseBody).contains("<numberOfElements>2</numberOfElements>");
         responseBody = httpClient.url(rootUrl()).setQueryParameter("page", "1")
-                .setQueryParameter("size", "1").getXml().get().getBody();
+                .setQueryParameter("size", "1").getXml().getBody();
         Assertions.assertThat(responseBody).contains("<totalElements>2</totalElements>");
         Assertions.assertThat(responseBody).contains("<numberOfElements>1</numberOfElements>");
     }
-    
-    @Test
-    public void testFindPaginatedResourcesReturnsBadRequestForAnInvalidPageNumber() throws InterruptedException, ExecutionException {
+
+    @Test(expectedExceptions = {HttpServerErrorException.class})
+    public void testFindPaginatedResourcesReturnsBadRequestForAnInvalidPageNumber() {
         Client httpClient = new Client();
-        httpClient.url(rootUrl()).xmlPost(new Sample("toto")).get();
-        httpClient.url(rootUrl()).xmlPost(new Sample("toto")).get();
+        httpClient.url(rootUrl()).xmlPost(new Sample("toto"));
+        httpClient.url(rootUrl()).xmlPost(new Sample("toto"));
         Response response = httpClient.url(rootUrl()).setQueryParameter("page","0")
-                .getXml().get();
+                .getXml();
         // TODO: Map IllegalArgumentException to 400 Bad Request
         Assertions.assertThat(response.getStatus()).isEqualTo(500);
         Assertions.assertThat(response.getBody()).contains("Page index must be greater than 0");
     }
 
-    @Test
-    public void testDeleteResource() throws IllegalArgumentException, IOException, InterruptedException,
-            ExecutionException {
+    @Test(expectedExceptions = {NotFoundException.class})
+    public void testDeleteResource() {
         Client httpClient = new Client();
         Sample r = new Sample("toto");
-        r = (Sample) httpClient.url(rootUrl()).xmlPost(r).get().resource(r.getClass());
+        r = (Sample) httpClient.url(rootUrl()).xmlPost(r).resource(r.getClass());
         Assertions.assertThat(r).isNotNull();
 
-        Response response = httpClient.url(rootUrl() + "/" + r.getId()).delete().get();
+        Response response = httpClient.url(rootUrl() + "/" + r.getId()).delete();
         Assertions.assertThat(response.getStatus()).isEqualTo(Http.NO_CONTENT);
 
-        response = httpClient.url(rootUrl() + "/" + r.getId()).get().get();
+        response = httpClient.url(rootUrl() + "/" + r.getId()).get();
         Assertions.assertThat(response.getStatus()).isEqualTo(Http.NOT_FOUND);
     }
 
     @Test
-    public void testFindResource() throws IllegalArgumentException, IOException, InterruptedException,
-            ExecutionException {
+    public void testFindResource() {
         Client httpClient = new Client();
         Sample r = new Sample("toto");
-        r = (Sample) httpClient.url(rootUrl()).xmlPost(r).get().resource(r.getClass());
+        r = (Sample) httpClient.url(rootUrl()).xmlPost(r).resource(r.getClass());
 
-        Response response = httpClient.url(rootUrl() + "/" + r.getId()).get().get();
+        Response response = httpClient.url(rootUrl() + "/" + r.getId()).get();
         Assertions.assertThat(response.getStatus()).isEqualTo(Http.OK);
     }
 
     @Test
-    public void testUpdate() throws IllegalArgumentException, IOException, InterruptedException, ExecutionException {
+    public void testUpdate() {
         Client httpClient = new Client();
         Sample r1 = new Sample("toto");
-        r1 = httpClient.url(rootUrl()).xmlPost(r1).get().resource(r1.getClass());
+        r1 = httpClient.url(rootUrl()).xmlPost(r1).resource(r1.getClass());
         Sample r2 = new Sample(r1);
         r2.setName("titi");
-        r2 = httpClient.url(rootUrl() + "/" + r1.getId()).xmlPut(r2).get().resource(r2.getClass());
+        r2 = httpClient.url(rootUrl() + "/" + r1.getId()).xmlPut(r2).resource(r2.getClass());
         Assertions.assertThat(r1).isNotEqualTo(r2);
         Assertions.assertThat(r1.getName()).contains("toto");
         Assertions.assertThat(r2.getName()).contains("titi");

--- a/resthub-web/resthub-web-server/src/test/java/org/resthub/web/controller/XmlServiceBasedRestControllerWebTest.java
+++ b/resthub-web/resthub-web-server/src/test/java/org/resthub/web/controller/XmlServiceBasedRestControllerWebTest.java
@@ -8,6 +8,9 @@ import org.resthub.test.common.AbstractWebTest;
 import org.resthub.web.Client;
 import org.resthub.web.Http;
 import org.resthub.web.Response;
+import org.resthub.web.exception.HttpServerErrorException;
+import org.resthub.web.exception.NotFoundException;
+import org.resthub.web.exception.NotImplementedException;
 import org.resthub.web.model.Sample;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Test;
@@ -24,109 +27,99 @@ public class XmlServiceBasedRestControllerWebTest extends AbstractWebTest {
 
     @AfterMethod
     public void tearDown() {
-        try {
-            new Client().url(rootUrl()).delete().get();
-        } catch (InterruptedException | ExecutionException e) {
-            Assertions.fail("Exception during delete all request", e);
-        }
+            new Client().url(rootUrl()).delete();
     }
 
     @Test
-    public void testCreateResource() throws IllegalArgumentException, InterruptedException, ExecutionException,
-            IOException {
+    public void testCreateResource() {
         Client httpClient = new Client();
         Sample r = new Sample("toto");
-        Response response = httpClient.url(rootUrl()).xmlPost(r).get();
+        Response response = httpClient.url(rootUrl()).xmlPost(r);
         r = (Sample) response.resource(r.getClass());
         Assertions.assertThat(r).isNotNull();
         Assertions.assertThat(r.getName()).isEqualTo("toto");
     }
     
     @Test
-    public void testFindAllResources() throws IllegalArgumentException, InterruptedException, ExecutionException,
-            IOException {
+    public void testFindAllResources() {
         Client httpClient = new Client();
-        httpClient.url(rootUrl()).jsonPost(new Sample("toto")).get();
-        httpClient.url(rootUrl()).jsonPost(new Sample("toto")).get();
-        String responseBody = httpClient.url(rootUrl()).getXml().get().getBody();
+        httpClient.url(rootUrl()).jsonPost(new Sample("toto"));
+        httpClient.url(rootUrl()).jsonPost(new Sample("toto"));
+        String responseBody = httpClient.url(rootUrl()).getXml().getBody();
         Assertions.assertThat(responseBody).contains("toto");
         Assertions.assertThat(responseBody).contains("<totalElements>2</totalElements>");
         Assertions.assertThat(responseBody).contains("<numberOfElements>2</numberOfElements>");
     }
     
-    @Test
-    public void testFindAllResourcesUnpaginated() throws IllegalArgumentException, InterruptedException, ExecutionException,
-            IOException {
+    @Test(expectedExceptions = {NotImplementedException.class})
+    public void testFindAllResourcesUnpaginated() {
         Client httpClient = new Client();
-        httpClient.url(rootUrl()).jsonPost(new Sample("toto")).get();
-        httpClient.url(rootUrl()).jsonPost(new Sample("toto")).get();
-        Response r = httpClient.url(rootUrl()).setQueryParameter("page", "no").getXml().get();
+        httpClient.url(rootUrl()).jsonPost(new Sample("toto"));
+        httpClient.url(rootUrl()).jsonPost(new Sample("toto"));
+        Response r = httpClient.url(rootUrl()).setQueryParameter("page", "no").getXml();
         Assertions.assertThat(r).isNotNull();
         Assertions.assertThat(r.getStatus()).isEqualTo(Http.NOT_IMPLEMENTED);
     }
     
     @Test
-    public void testFindPaginatedResources() throws IllegalArgumentException, InterruptedException,
-            ExecutionException, IOException {
+    public void testFindPaginatedResources() {
         Client httpClient = new Client();
-        httpClient.url(rootUrl()).xmlPost(new Sample("toto")).get();
-        httpClient.url(rootUrl()).xmlPost(new Sample("toto")).get();
-        String responseBody = httpClient.url(rootUrl()).setQueryParameter("page", "1").getXml().get()
+        httpClient.url(rootUrl()).xmlPost(new Sample("toto"));
+        httpClient.url(rootUrl()).xmlPost(new Sample("toto"));
+        String responseBody = httpClient.url(rootUrl()).setQueryParameter("page", "1").getXml()
                 .getBody();
         Assertions.assertThat(responseBody).contains("<totalElements>2</totalElements>");
         Assertions.assertThat(responseBody).contains("<numberOfElements>2</numberOfElements>");
         responseBody = httpClient.url(rootUrl()).setQueryParameter("page", "1")
-                .setQueryParameter("size", "1").getXml().get().getBody();
+                .setQueryParameter("size", "1").getXml().getBody();
         Assertions.assertThat(responseBody).contains("<totalElements>2</totalElements>");
         Assertions.assertThat(responseBody).contains("<numberOfElements>1</numberOfElements>");
     }
     
-    @Test
-    public void testFindPaginatedResourcesReturnsBadRequestForAnInvalidPageNumber() throws InterruptedException, ExecutionException {
+    @Test(expectedExceptions = {HttpServerErrorException.class})
+    public void testFindPaginatedResourcesReturnsBadRequestForAnInvalidPageNumber() {
         Client httpClient = new Client();
-        httpClient.url(rootUrl()).xmlPost(new Sample("toto")).get();
-        httpClient.url(rootUrl()).xmlPost(new Sample("toto")).get();
+        httpClient.url(rootUrl()).xmlPost(new Sample("toto"));
+        httpClient.url(rootUrl()).xmlPost(new Sample("toto"));
         Response response = httpClient.url(rootUrl()).setQueryParameter("page","0")
-                .getXml().get();
+                .getXml();
         // TODO: Map IllegalArgumentException to 400 Bad Request
         Assertions.assertThat(response.getStatus()).isEqualTo(500);
         Assertions.assertThat(response.getBody()).contains("Page index must be greater than 0");
     }
 
-    @Test
-    public void testDeleteResource() throws IllegalArgumentException, IOException, InterruptedException,
-            ExecutionException {
+    @Test(expectedExceptions = {NotFoundException.class})
+    public void testDeleteResource() {
         Client httpClient = new Client();
         Sample r = new Sample("toto");
-        r = httpClient.url(rootUrl()).xmlPost(r).get().resource(r.getClass());
+        r = httpClient.url(rootUrl()).xmlPost(r).resource(r.getClass());
         Assertions.assertThat(r).isNotNull();
 
-        Response response = httpClient.url(rootUrl() + "/" + r.getId()).delete().get();
+        Response response = httpClient.url(rootUrl() + "/" + r.getId()).delete();
         Assertions.assertThat(response.getStatus()).isEqualTo(Http.NO_CONTENT);
 
-        response = httpClient.url(rootUrl() + "/" + r.getId()).get().get();
+        response = httpClient.url(rootUrl() + "/" + r.getId()).get();
         Assertions.assertThat(response.getStatus()).isEqualTo(Http.NOT_FOUND);
     }
 
     @Test
-    public void testFindResource() throws IllegalArgumentException, IOException, InterruptedException,
-            ExecutionException {
+    public void testFindResource() {
         Client httpClient = new Client();
         Sample r = new Sample("toto");
-        r = (Sample) httpClient.url(rootUrl()).xmlPost(r).get().resource(r.getClass());
+        r = (Sample) httpClient.url(rootUrl()).xmlPost(r).resource(r.getClass());
 
-        Response response = httpClient.url(rootUrl() + "/" + r.getId()).get().get();
+        Response response = httpClient.url(rootUrl() + "/" + r.getId()).get();
         Assertions.assertThat(response.getStatus()).isEqualTo(Http.OK);
     }
 
     @Test
-    public void testUpdate() throws IllegalArgumentException, IOException, InterruptedException, ExecutionException {
+    public void testUpdate() {
         Client httpClient = new Client();
         Sample r1 = new Sample("toto");
-        r1 = httpClient.url(rootUrl()).xmlPost(r1).get().resource(r1.getClass());
+        r1 = httpClient.url(rootUrl()).xmlPost(r1).resource(r1.getClass());
         Sample r2 = new Sample(r1);
         r2.setName("titi");
-        r2 = httpClient.url(rootUrl() + "/" + r1.getId()).xmlPut(r2).get().resource(r2.getClass());
+        r2 = httpClient.url(rootUrl() + "/" + r1.getId()).xmlPut(r2).resource(r2.getClass());
         Assertions.assertThat(r1).isNotEqualTo(r2);
         Assertions.assertThat(r1.getName()).contains("toto");
         Assertions.assertThat(r2.getName()).contains("titi");


### PR DESCRIPTION
This PR contains:
- fixes issue #109
- tests for query params in url given to the HTTP Client
- add both async and sync methods in HTTP Client (default methods use the sync version)
