### PR TITLE
Mongodb authentification

### DIFF
--- a/resthub-mongodb/src/main/resources/resthubContext.xml
+++ b/resthub-mongodb/src/main/resources/resthubContext.xml
@@ -17,6 +17,8 @@
         <prop key="database.dbname">resthub</prop>
         <prop key="database.host">localhost</prop>
         <prop key="database.port">27017</prop>
+        <prop key="database.username"></prop>
+        <prop key="database.password"></prop>
 
         <prop key="database.connectionsPerHost">10</prop>
         <prop key="database.threadsAllowedToBlockForConnectionMultiplier">5</prop>
@@ -45,7 +47,8 @@
             write-fsync="${database.writeFsync}" />
     </mongo:mongo>
 
-    <mongo:db-factory id="mongoDbFactory" dbname="${database.dbname}" mongo-ref="mongo" />
+    <mongo:db-factory id="mongoDbFactory" dbname="${database.dbname}"
+                      username="${database.username}" password="${database.password}" mongo-ref="mongo" />
 
     <bean id="mongoTemplate" class="org.springframework.data.mongodb.core.MongoTemplate">
         <constructor-arg ref="mongoDbFactory" />


### PR DESCRIPTION
Added two properties to have authentification on mongodb : username and password.
By default, properties are empty, so Spring Data will still try to connect with no user (default mongodb mode).
