### PR TITLE
Rename Spring profiles without the resthub- prefix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
         <slf4j.version>1.7.1</slf4j.version>
         <servlet.version>3.0.1</servlet.version>
 
-        <jetty.version>8.1.7.v20120910</jetty.version>
+        <jetty.version>8.1.8.v20121106</jetty.version>
         <jetty.port>8080</jetty.port>
 
         <testng.version>6.8</testng.version>
@@ -327,7 +327,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-failsafe-plugin</artifactId>
-                    <version>2.9</version>
+                    <version>2.12.4</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/resthub-jpa/src/main/resources/resthubContext.xml
+++ b/resthub-jpa/src/main/resources/resthubContext.xml
@@ -1,4 +1,4 @@
-<beans profile="resthub-jpa" xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<beans profile="jpa" xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns:context="http://www.springframework.org/schema/context" xmlns:util="http://www.springframework.org/schema/util"
     xmlns:tx="http://www.springframework.org/schema/tx"
     xsi:schemaLocation="http://www.springframework.org/schema/beans

--- a/resthub-jpa/src/test/java/org/resthub/jpa/test/StandaloneEntityRepositoryTest.java
+++ b/resthub-jpa/src/test/java/org/resthub/jpa/test/StandaloneEntityRepositoryTest.java
@@ -14,7 +14,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Test;
 
-@ActiveProfiles("resthub-jpa")
+@ActiveProfiles("jpa")
 public class StandaloneEntityRepositoryTest extends AbstractTransactionalTest {
 
     @Inject

--- a/resthub-mongodb/src/main/resources/resthubContext.xml
+++ b/resthub-mongodb/src/main/resources/resthubContext.xml
@@ -1,4 +1,4 @@
-<beans profile="resthub-mongodb" xmlns="http://www.springframework.org/schema/beans"
+<beans profile="mongodb" xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:context="http://www.springframework.org/schema/context"
        xmlns:util="http://www.springframework.org/schema/util" xmlns:mongo="http://www.springframework.org/schema/data/mongo"
        xsi:schemaLocation="http://www.springframework.org/schema/beans

--- a/resthub-test/src/main/java/org/resthub/test/AbstractWebTest.java
+++ b/resthub-test/src/main/java/org/resthub/test/AbstractWebTest.java
@@ -72,7 +72,7 @@ public abstract class AbstractWebTest {
     
     /**
      * List of Spring profiles (use comma separator) to activate
-     * For example "resthub-web-server,resthub-jpa"
+     * For example "web-server,jpa"
      */
     protected String activeProfiles = "";
     

--- a/resthub-web/resthub-web-server/src/main/java/org/resthub/web/controller/LogController.java
+++ b/resthub-web/resthub-web-server/src/main/java/org/resthub/web/controller/LogController.java
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.*;
  * Log controller for client logging
  */
 @Controller
-@Profile("resthub-client-logging")
+@Profile("client-logging")
 public class LogController {
 
     private LogStrategy logStrategy;

--- a/resthub-web/resthub-web-server/src/main/java/org/resthub/web/log/DefaultLogStrategy.java
+++ b/resthub-web/resthub-web-server/src/main/java/org/resthub/web/log/DefaultLogStrategy.java
@@ -10,7 +10,7 @@ import org.springframework.context.annotation.Profile;
  * Default log strategy
  */
 @Named("defaultLogStrategy")
-@Profile("resthub-client-logging")
+@Profile("client-logging")
 public class DefaultLogStrategy implements LogStrategy {
     
     private static final Logger LOGGER = LoggerFactory.getLogger("JSLogger");

--- a/resthub-web/resthub-web-server/src/main/resources/resthubContext.xml
+++ b/resthub-web/resthub-web-server/src/main/resources/resthubContext.xml
@@ -1,4 +1,4 @@
-<beans profile="resthub-web-server" xmlns="http://www.springframework.org/schema/beans"
+<beans profile="web-server" xmlns="http://www.springframework.org/schema/beans"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns:mvc="http://www.springframework.org/schema/mvc"
     xmlns:context="http://www.springframework.org/schema/context"

--- a/resthub-web/resthub-web-server/src/test/java/org/resthub/web/test/AnnotationConfigAwareWebTest.java
+++ b/resthub-web/resthub-web-server/src/test/java/org/resthub/web/test/AnnotationConfigAwareWebTest.java
@@ -9,7 +9,7 @@ import org.testng.annotations.Test;
 public class AnnotationConfigAwareWebTest extends AbstractWebTest {
     
     AnnotationConfigAwareWebTest() {
-        super("resthub-web-server,resthub-jpa");
+        super("web-server,jpa");
     }
     
     @Test

--- a/resthub-web/resthub-web-server/src/test/java/org/resthub/web/test/ExceptionMappingWebTest.java
+++ b/resthub-web/resthub-web-server/src/test/java/org/resthub/web/test/ExceptionMappingWebTest.java
@@ -16,7 +16,7 @@ import org.testng.annotations.Test;
 public class ExceptionMappingWebTest extends AbstractWebTest {
     
     public ExceptionMappingWebTest() {
-         super("resthub-web-server,resthub-jpa");
+         super("web-server,jpa");
     }
     
     @Test(expectedExceptions=NotAcceptableClientException.class)

--- a/resthub-web/resthub-web-server/src/test/java/org/resthub/web/test/JsonRepositoryBasedRestControllerTest.java
+++ b/resthub-web/resthub-web-server/src/test/java/org/resthub/web/test/JsonRepositoryBasedRestControllerTest.java
@@ -17,7 +17,7 @@ import org.testng.annotations.Test;
 public class JsonRepositoryBasedRestControllerTest extends AbstractWebTest {
 
     public JsonRepositoryBasedRestControllerTest() {
-        super("resthub-web-server,resthub-jpa");
+        super("web-server,jpa");
     }
 
     @AfterMethod

--- a/resthub-web/resthub-web-server/src/test/java/org/resthub/web/test/JsonServiceBasedRestControllerTest.java
+++ b/resthub-web/resthub-web-server/src/test/java/org/resthub/web/test/JsonServiceBasedRestControllerTest.java
@@ -17,7 +17,7 @@ import org.testng.annotations.Test;
 public class JsonServiceBasedRestControllerTest extends AbstractWebTest {
 
     public JsonServiceBasedRestControllerTest() {
-        super("resthub-web-server,resthub-jpa");
+        super("web-server,jpa");
     }
 
     @AfterMethod

--- a/resthub-web/resthub-web-server/src/test/java/org/resthub/web/test/SluggableRepositoryBasedRestControllerTest.java
+++ b/resthub-web/resthub-web-server/src/test/java/org/resthub/web/test/SluggableRepositoryBasedRestControllerTest.java
@@ -14,7 +14,7 @@ import org.testng.annotations.Test;
 public class SluggableRepositoryBasedRestControllerTest extends AbstractWebTest {
 
      public SluggableRepositoryBasedRestControllerTest() {
-        super("resthub-web-server,resthub-jpa");
+        super("web-server,jpa");
     }
     
     @AfterMethod

--- a/resthub-web/resthub-web-server/src/test/java/org/resthub/web/test/SluggableServiceBasedRestControllerTest.java
+++ b/resthub-web/resthub-web-server/src/test/java/org/resthub/web/test/SluggableServiceBasedRestControllerTest.java
@@ -13,7 +13,7 @@ import org.testng.annotations.Test;
 public class SluggableServiceBasedRestControllerTest extends AbstractWebTest {
 
     public SluggableServiceBasedRestControllerTest() {
-        super("resthub-web-server,resthub-jpa");
+        super("web-server,jpa");
     }   
 
     @AfterMethod

--- a/resthub-web/resthub-web-server/src/test/java/org/resthub/web/test/XmlRepositoryBasedRestControllerWebTest.java
+++ b/resthub-web/resthub-web-server/src/test/java/org/resthub/web/test/XmlRepositoryBasedRestControllerWebTest.java
@@ -17,7 +17,7 @@ import org.testng.annotations.Test;
 public class XmlRepositoryBasedRestControllerWebTest extends AbstractWebTest {
 
     public XmlRepositoryBasedRestControllerWebTest() {
-         super("resthub-web-server,resthub-jpa");
+         super("web-server,jpa");
     }
 
     @AfterMethod

--- a/resthub-web/resthub-web-server/src/test/java/org/resthub/web/test/XmlServiceBasedRestControllerWebTest.java
+++ b/resthub-web/resthub-web-server/src/test/java/org/resthub/web/test/XmlServiceBasedRestControllerWebTest.java
@@ -17,7 +17,7 @@ import org.testng.annotations.Test;
 public class XmlServiceBasedRestControllerWebTest extends AbstractWebTest {
 
     public XmlServiceBasedRestControllerWebTest() {
-         super("resthub-web-server,resthub-jpa");
+         super("web-server,jpa");
     }
 
     @AfterMethod


### PR DESCRIPTION
Since these profiles may also be used for application scope beans. Documentation and todo example updates will follow ...
