### PR TITLE
Remove optional qualifier for spring-data-commons-core dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>org.resthub</groupId>
     <artifactId>resthub-spring-stack</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>RESThub Spring stack</name>
     <url>http://resthub.org</url>

--- a/resthub-common/pom.xml
+++ b/resthub-common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.resthub</groupId>
         <artifactId>resthub-spring-stack</artifactId>
-        <version>2.0.1-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -43,7 +43,6 @@
         <dependency>
             <groupId>org.springframework.data</groupId>
             <artifactId>spring-data-commons-core</artifactId>
-            <optional>true</optional>
             <exclusions>
                 <exclusion>
                     <groupId>org.springframework</groupId>

--- a/resthub-jpa/pom.xml
+++ b/resthub-jpa/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.resthub</groupId>
         <artifactId>resthub-spring-stack</artifactId>
-        <version>2.0.1-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/resthub-mongodb/pom.xml
+++ b/resthub-mongodb/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.resthub</groupId>
         <artifactId>resthub-spring-stack</artifactId>
-        <version>2.0.1-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/resthub-test/pom.xml
+++ b/resthub-test/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.resthub</groupId>
         <artifactId>resthub-spring-stack</artifactId>
-        <version>2.0.1-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/resthub-web/pom.xml
+++ b/resthub-web/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.resthub</groupId>
         <artifactId>resthub-spring-stack</artifactId>
-        <version>2.0.1-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/resthub-web/resthub-web-client/pom.xml
+++ b/resthub-web/resthub-web-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>resthub-web</artifactId>
         <groupId>org.resthub</groupId>
-        <version>2.0.1-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/resthub-web/resthub-web-common/pom.xml
+++ b/resthub-web/resthub-web-common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>resthub-web</artifactId>
         <groupId>org.resthub</groupId>
-        <version>2.0.1-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/resthub-web/resthub-web-server/pom.xml
+++ b/resthub-web/resthub-web-server/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>resthub-web</artifactId>
         <groupId>org.resthub</groupId>
-        <version>2.0.1-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
While working on fixing multi-module archetypes, I found an issue : spring-data-commons-core is optional. Since we have methods like Page findAll(Pageable p) exposed in CrudService interface, it should not be optional in 2.0 release.

I also created an issue for RESThub 2.1 in order to make a clean and long term fix
https://github.com/resthub/resthub-spring-stack/issues/152

I will also commit a fix for resthub-archetypes multi-module projects shortly.
