### PR TITLE
add CORSFilter in spring stack

### DIFF
--- a/resthub-test/src/main/java/org/resthub/test/AbstractWebTest.java
+++ b/resthub-test/src/main/java/org/resthub/test/AbstractWebTest.java
@@ -178,7 +178,7 @@ public abstract class AbstractWebTest {
             }
 
             // Customize context then start the server.
-            server.setHandler(this.customizeContextHandler(context));
+            server.setHandler(customizeContextHandler(context));
             server.start();
 
             if (this.startServerOnce) {

--- a/resthub-test/src/main/java/org/resthub/test/AbstractWebTest.java
+++ b/resthub-test/src/main/java/org/resthub/test/AbstractWebTest.java
@@ -1,9 +1,5 @@
 package org.resthub.test;
 
-import java.util.EnumSet;
-
-import javax.servlet.DispatcherType;
-
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.servlet.DefaultServlet;
 import org.eclipse.jetty.servlet.ServletContextHandler;
@@ -17,16 +13,20 @@ import org.springframework.web.servlet.DispatcherServlet;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 
+import javax.servlet.DispatcherType;
+import javax.servlet.ServletException;
+import java.util.EnumSet;
+
 /**
  * Base class for your webservice tests, based on Jetty and with preconfigured Spring configuration. By default, a single
  * Jetty server is started for all tests so you should take care of cleanup your data after your tests.
- *
+ * <p/>
  * If you want restart Jetty server after each test class, set startServerOnce to false and eventually customize port (in order to
  * avoid Jetty server listening on the same port conflict) in the constructor.
- *
+ * <p/>
  * By default it use XML context configuration. In order to use @Configuration class, you should set this.annotationBasedConfig = true
  * and this.contextLocations = "org.mypackage"; in your class constructor.
- * 
+ * <p/>
  * Usually you will have to redefine the Spring profiles used by your application by calling AbstractWebTest super constructor
  */
 public abstract class AbstractWebTest {
@@ -50,12 +50,12 @@ public abstract class AbstractWebTest {
      * Class specific Jetty embedded server that will run your application
      */
     protected Server server;
-    
+
     /**
      * RESThub http client used to send test requests
      */
     protected Client client;
-    
+
     /**
      * Default rootUrl used to send requests
      */
@@ -64,62 +64,65 @@ public abstract class AbstractWebTest {
     /**
      * Default Spring contexts imported. You should not have to customize this one frequently, prefer using Spring 3.1
      * profiles in order to control configuration activation.
-     * 
+     * <p/>
      * If you use JavaConfig based configuration, use it to specify the package where belong your @Configuration classes
      */
     protected String contextLocations = "classpath*:resthubContext.xml classpath*:applicationContext.xml";
-    
+
     /**
      * List of Spring profiles (use comma separator) to activate
      * For example "resthub-web-server,resthub-jpa"
      */
     protected String activeProfiles = "";
-    
+
     /**
      * When set to true, activate Spring 3.1 JavaConfig based configuration, by setting context param contextClass to org.springframework.web.context.support.AnnotationConfigWebApplicationContext
      */
     protected Boolean annotationBasedConfig = false;
-    
+
     /**
      * Default constructor
      */
     public AbstractWebTest() {
         client = new Client();
     }
-       
+
     /**
      * Constructor allowing to specify Spring active profiles
+     *
      * @param activeProfiles coma separated list of profiles
      */
     public AbstractWebTest(String activeProfiles) {
         this();
         this.activeProfiles = activeProfiles;
     }
-    
+
     /**
      * Constructor allowing to specify HTTP port used to run the server
+     *
      * @param port HTTP port used for running web tests, default is 9797
      */
     public AbstractWebTest(int port) {
         this();
         this.port = port;
     }
-    
+
     /**
      * Constructor allowing to specify Spring active profiles and HTTP port used to run the server
+     *
      * @param activeProfiles coma separated list of profiles
-     * @param port HTTP port used for running web tests, default is 9797
+     * @param port           HTTP port used for running web tests, default is 9797
      */
     public AbstractWebTest(String activeProfiles, int port) {
         this(port);
         this.activeProfiles = activeProfiles;
     }
-        
+
     /**
      * Define in OpenEntityManagerInViewFilter should be activated or not. Default to false
      */
     protected Boolean useOpenEntityManagerInViewFilter = false;
-    
+
     protected int servletContextHandlerOption = ServletContextHandler.SESSIONS;
 
     protected static final Logger logger = LoggerFactory.getLogger(AbstractWebTest.class);
@@ -127,12 +130,13 @@ public abstract class AbstractWebTest {
     /**
      * You should override it in order to customize the servlet context handler
      */
-    protected ServletContextHandler customizeContextHandler(ServletContextHandler context) {
+    protected ServletContextHandler customizeContextHandler(ServletContextHandler context) throws ServletException {
         return context;
     }
-    
+
     /**
      * Send a request to the embedded test webserver
+     *
      * @param urlSuffix The end of the request without starting /, for example "todo" urlSuffix will send a request to "http://localhost:9797/todo"
      * @return The requestHolder that will allow you to build and send the request
      */
@@ -142,12 +146,12 @@ public abstract class AbstractWebTest {
 
     @BeforeClass
     public void beforeClass() throws Exception {
-        if((!this.startServerOnce) || (reusableServer == null)) {
+        if ((!this.startServerOnce) || (reusableServer == null)) {
             server = new Server(port);
 
             // Add a context for authorization service
             ServletContextHandler context = new ServletContextHandler(servletContextHandlerOption);
-            if(this.annotationBasedConfig) {
+            if (this.annotationBasedConfig) {
                 context.getInitParams().put("contextClass", "org.springframework.web.context.support.AnnotationConfigWebApplicationContext");
             }
             context.getInitParams().put("contextConfigLocation", contextLocations);
@@ -173,12 +177,11 @@ public abstract class AbstractWebTest {
                 context.addFilter(OpenEntityManagerInViewFilter.class, "/*", EnumSet.of(DispatcherType.REQUEST));
             }
 
-            // Starts the server.
-            server.setHandler(context);
-
+            // Customize context then start the server.
+            server.setHandler(this.customizeContextHandler(context));
             server.start();
 
-            if(this.startServerOnce) {
+            if (this.startServerOnce) {
                 reusableServer = server;
             }
         }

--- a/resthub-web/resthub-web-server/pom.xml
+++ b/resthub-web/resthub-web-server/pom.xml
@@ -13,6 +13,10 @@
     <name>RESThub Webservice Server</name>
     <description>RESThub support for REST webservices based on Spring MVC</description>
 
+    <properties>
+        <cors.filter.version>1.3.2</cors.filter.version>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.resthub</groupId>
@@ -55,6 +59,12 @@
         <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.thetransactioncompany</groupId>
+            <artifactId>cors-filter</artifactId>
+            <version>${cors.filter.version}</version>
         </dependency>
 
         <dependency>

--- a/resthub-web/resthub-web-server/src/test/java/org/resthub/web/test/CorsFilterTest.java
+++ b/resthub-web/resthub-web-server/src/test/java/org/resthub/web/test/CorsFilterTest.java
@@ -20,7 +20,8 @@ import static org.fest.assertions.api.Assertions.assertThat;
 public class CorsFilterTest extends AbstractWebTest {
 
     public CorsFilterTest() {
-        super("resthub-web-server,resthub-jpa");
+        super("resthub-web-server,resthub-jpa", 9798);
+        this.startServerOnce=false;
     }
 
     @Override
@@ -41,10 +42,8 @@ public class CorsFilterTest extends AbstractWebTest {
 
     @Test
     public void testCORSOriginHeader() {
-
         Sample r = new Sample("toto");
         r = this.request("service-based").jsonPost(r).resource(r.getClass());
-
         Response response = this.request("service-based/" + r.getId()).setHeader("Origin", "http://example.org").get();
         Assertions.assertThat(response.getStatus()).isEqualTo(Http.OK);
         assertThat(response.getHeader("Access-Control-Allow-Origin")).isNotNull().isEqualTo("http://example.org");

--- a/resthub-web/resthub-web-server/src/test/java/org/resthub/web/test/CorsFilterTest.java
+++ b/resthub-web/resthub-web-server/src/test/java/org/resthub/web/test/CorsFilterTest.java
@@ -1,0 +1,58 @@
+package org.resthub.web.test;
+
+import com.thetransactioncompany.cors.CORSFilter;
+import org.eclipse.jetty.servlet.FilterHolder;
+import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.fest.assertions.api.Assertions;
+import org.resthub.test.AbstractWebTest;
+import org.resthub.web.Http;
+import org.resthub.web.Response;
+import org.resthub.web.model.Sample;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.Test;
+
+import javax.servlet.DispatcherType;
+import javax.servlet.ServletException;
+import java.util.EnumSet;
+
+import static org.fest.assertions.api.Assertions.assertThat;
+
+public class CorsFilterTest extends AbstractWebTest {
+
+    public CorsFilterTest() {
+        super("resthub-web-server,resthub-jpa");
+    }
+
+    @Override
+    protected ServletContextHandler customizeContextHandler(ServletContextHandler context) throws ServletException {
+
+        /*
+         See http://software.dzhuvinov.com/cors-filter-configuration.html
+         for additional CORSFilter init parameters
+         */
+        CORSFilter corsFilter = new CORSFilter();
+        FilterHolder holder = new FilterHolder(corsFilter);
+        // some HTTP methods are not allowed by this filter by default
+        holder.setInitParameter("cors.supportedMethods", "GET, POST, PUT, DELETE, HEAD, OPTIONS");
+        context.addFilter(holder, "/*", EnumSet.of(DispatcherType.REQUEST));
+
+        return context;
+    }
+
+    @Test
+    public void testCORSOriginHeader() {
+
+        Sample r = new Sample("toto");
+        r = this.request("service-based").jsonPost(r).resource(r.getClass());
+
+        Response response = this.request("service-based/" + r.getId()).setHeader("Origin", "http://example.org").get();
+        Assertions.assertThat(response.getStatus()).isEqualTo(Http.OK);
+        assertThat(response.getHeader("Access-Control-Allow-Origin")).isNotNull().isEqualTo("http://example.org");
+    }
+
+    @AfterMethod
+    public void tearDown() {
+        this.request("service-based").delete();
+    }
+
+}


### PR DESCRIPTION
Fixes issue #163
- added CORSFitler as a dependency
- tested the Allow-Origin header

Also fixes bug: customizeContextHandler was never called in AbstractWebTest - so users couldn't customize the test servlet context.
