### PR TITLE
returns content with empty constraints instead of null - no content

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>org.resthub</groupId>
     <artifactId>resthub-spring-stack</artifactId>
-    <version>2.1.4-SNAPSHOT</version>
+    <version>2.1.3</version>
     <packaging>pom</packaging>
     <name>RESThub Spring stack</name>
     <url>http://resthub.org</url>
@@ -120,7 +120,7 @@
         <connection>scm:git:git@github.com:resthub/resthub-spring-stack.git</connection>
         <developerConnection>scm:git:git@github.com:resthub/resthub-spring-stack.git</developerConnection>
         <url>scm:git:git@github.com:resthub/resthub-spring-stack.git</url>
-      <tag>HEAD</tag>
+      <tag>resthub-spring-stack-2.1.3</tag>
   </scm>
 
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>org.resthub</groupId>
     <artifactId>resthub-spring-stack</artifactId>
-    <version>2.1.3-SNAPSHOT</version>
+    <version>2.1.3</version>
     <packaging>pom</packaging>
     <name>RESThub Spring stack</name>
     <url>http://resthub.org</url>
@@ -120,7 +120,7 @@
         <connection>scm:git:git@github.com:resthub/resthub-spring-stack.git</connection>
         <developerConnection>scm:git:git@github.com:resthub/resthub-spring-stack.git</developerConnection>
         <url>scm:git:git@github.com:resthub/resthub-spring-stack.git</url>
-      <tag>HEAD</tag>
+      <tag>resthub-spring-stack-2.1.3</tag>
   </scm>
 
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>org.resthub</groupId>
     <artifactId>resthub-spring-stack</artifactId>
-    <version>2.1.3</version>
+    <version>2.1.4-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>RESThub Spring stack</name>
     <url>http://resthub.org</url>
@@ -120,7 +120,7 @@
         <connection>scm:git:git@github.com:resthub/resthub-spring-stack.git</connection>
         <developerConnection>scm:git:git@github.com:resthub/resthub-spring-stack.git</developerConnection>
         <url>scm:git:git@github.com:resthub/resthub-spring-stack.git</url>
-      <tag>resthub-spring-stack-2.1.3</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <dependencyManagement>

--- a/resthub-common/pom.xml
+++ b/resthub-common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.resthub</groupId>
         <artifactId>resthub-spring-stack</artifactId>
-        <version>2.1.3-SNAPSHOT</version>
+        <version>2.1.3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/resthub-common/pom.xml
+++ b/resthub-common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.resthub</groupId>
         <artifactId>resthub-spring-stack</artifactId>
-        <version>2.1.3</version>
+        <version>2.1.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/resthub-common/pom.xml
+++ b/resthub-common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.resthub</groupId>
         <artifactId>resthub-spring-stack</artifactId>
-        <version>2.1.4-SNAPSHOT</version>
+        <version>2.1.3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/resthub-jpa/pom.xml
+++ b/resthub-jpa/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.resthub</groupId>
         <artifactId>resthub-spring-stack</artifactId>
-        <version>2.1.3-SNAPSHOT</version>
+        <version>2.1.3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/resthub-jpa/pom.xml
+++ b/resthub-jpa/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.resthub</groupId>
         <artifactId>resthub-spring-stack</artifactId>
-        <version>2.1.3</version>
+        <version>2.1.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/resthub-jpa/pom.xml
+++ b/resthub-jpa/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.resthub</groupId>
         <artifactId>resthub-spring-stack</artifactId>
-        <version>2.1.4-SNAPSHOT</version>
+        <version>2.1.3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/resthub-mongodb/pom.xml
+++ b/resthub-mongodb/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.resthub</groupId>
         <artifactId>resthub-spring-stack</artifactId>
-        <version>2.1.3-SNAPSHOT</version>
+        <version>2.1.3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/resthub-mongodb/pom.xml
+++ b/resthub-mongodb/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.resthub</groupId>
         <artifactId>resthub-spring-stack</artifactId>
-        <version>2.1.3</version>
+        <version>2.1.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/resthub-mongodb/pom.xml
+++ b/resthub-mongodb/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.resthub</groupId>
         <artifactId>resthub-spring-stack</artifactId>
-        <version>2.1.4-SNAPSHOT</version>
+        <version>2.1.3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/resthub-test/pom.xml
+++ b/resthub-test/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.resthub</groupId>
         <artifactId>resthub-spring-stack</artifactId>
-        <version>2.1.3-SNAPSHOT</version>
+        <version>2.1.3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/resthub-test/pom.xml
+++ b/resthub-test/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.resthub</groupId>
         <artifactId>resthub-spring-stack</artifactId>
-        <version>2.1.3</version>
+        <version>2.1.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/resthub-test/pom.xml
+++ b/resthub-test/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.resthub</groupId>
         <artifactId>resthub-spring-stack</artifactId>
-        <version>2.1.4-SNAPSHOT</version>
+        <version>2.1.3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/resthub-web/pom.xml
+++ b/resthub-web/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.resthub</groupId>
         <artifactId>resthub-spring-stack</artifactId>
-        <version>2.1.3-SNAPSHOT</version>
+        <version>2.1.3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/resthub-web/pom.xml
+++ b/resthub-web/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.resthub</groupId>
         <artifactId>resthub-spring-stack</artifactId>
-        <version>2.1.3</version>
+        <version>2.1.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/resthub-web/pom.xml
+++ b/resthub-web/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.resthub</groupId>
         <artifactId>resthub-spring-stack</artifactId>
-        <version>2.1.4-SNAPSHOT</version>
+        <version>2.1.3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/resthub-web/resthub-web-client/pom.xml
+++ b/resthub-web/resthub-web-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>resthub-web</artifactId>
         <groupId>org.resthub</groupId>
-        <version>2.1.3-SNAPSHOT</version>
+        <version>2.1.3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/resthub-web/resthub-web-client/pom.xml
+++ b/resthub-web/resthub-web-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>resthub-web</artifactId>
         <groupId>org.resthub</groupId>
-        <version>2.1.3</version>
+        <version>2.1.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/resthub-web/resthub-web-client/pom.xml
+++ b/resthub-web/resthub-web-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>resthub-web</artifactId>
         <groupId>org.resthub</groupId>
-        <version>2.1.4-SNAPSHOT</version>
+        <version>2.1.3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/resthub-web/resthub-web-common/pom.xml
+++ b/resthub-web/resthub-web-common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>resthub-web</artifactId>
         <groupId>org.resthub</groupId>
-        <version>2.1.3-SNAPSHOT</version>
+        <version>2.1.3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/resthub-web/resthub-web-common/pom.xml
+++ b/resthub-web/resthub-web-common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>resthub-web</artifactId>
         <groupId>org.resthub</groupId>
-        <version>2.1.3</version>
+        <version>2.1.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/resthub-web/resthub-web-common/pom.xml
+++ b/resthub-web/resthub-web-common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>resthub-web</artifactId>
         <groupId>org.resthub</groupId>
-        <version>2.1.4-SNAPSHOT</version>
+        <version>2.1.3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/resthub-web/resthub-web-server/pom.xml
+++ b/resthub-web/resthub-web-server/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>resthub-web</artifactId>
         <groupId>org.resthub</groupId>
-        <version>2.1.3-SNAPSHOT</version>
+        <version>2.1.3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/resthub-web/resthub-web-server/pom.xml
+++ b/resthub-web/resthub-web-server/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>resthub-web</artifactId>
         <groupId>org.resthub</groupId>
-        <version>2.1.3</version>
+        <version>2.1.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/resthub-web/resthub-web-server/pom.xml
+++ b/resthub-web/resthub-web-server/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>resthub-web</artifactId>
         <groupId>org.resthub</groupId>
-        <version>2.1.4-SNAPSHOT</version>
+        <version>2.1.3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/resthub-web/resthub-web-server/src/main/java/org/resthub/web/validation/ModelConstraint.java
+++ b/resthub-web/resthub-web-server/src/main/java/org/resthub/web/validation/ModelConstraint.java
@@ -16,6 +16,7 @@ public class ModelConstraint {
 
     public ModelConstraint(String modelRef) {
         this.modelRef = modelRef;
+        this.constraints = new HashMap<String, List<ValidationConstraint>>();
     }
 
     @JsonProperty(value = "model")

--- a/resthub-web/resthub-web-server/src/main/java/org/resthub/web/validation/ValidationServiceImpl.java
+++ b/resthub-web/resthub-web-server/src/main/java/org/resthub/web/validation/ValidationServiceImpl.java
@@ -36,11 +36,10 @@ public class ValidationServiceImpl implements ValidationService {
 
     @Override
     public ModelConstraint getConstraintsForClass(Class<?> clazz, Locale locale) {
-        ModelConstraint modelConstraint = null;
+        ModelConstraint modelConstraint = new ModelConstraint(clazz.getCanonicalName());;
         BeanDescriptor bd = VALIDATOR.getConstraintsForClass(clazz);
 
         if (bd.isBeanConstrained() && !Modifier.isAbstract(clazz.getModifiers())) {
-            modelConstraint = new ModelConstraint(clazz.getCanonicalName());
             modelConstraint.setConstraints(this.getConstraints(bd, locale));
         }
 

--- a/resthub-web/resthub-web-server/src/test/java/org/resthub/web/validation/controller/JsonValidationControllerIntegrationTest.java
+++ b/resthub-web/resthub-web-server/src/test/java/org/resthub/web/validation/controller/JsonValidationControllerIntegrationTest.java
@@ -5,9 +5,7 @@ import org.fest.assertions.api.Assertions;
 import org.resthub.test.AbstractWebTest;
 import org.resthub.web.Response;
 import org.resthub.web.validation.ModelConstraint;
-import org.resthub.web.validation.model.AModel;
-import org.resthub.web.validation.model.ClassLevelConstraintModel;
-import org.resthub.web.validation.model.InheritedClassLevelConstraintModel;
+import org.resthub.web.validation.model.*;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
@@ -78,5 +76,21 @@ public class JsonValidationControllerIntegrationTest extends AbstractWebTest {
 
         Assertions.assertThat(response.getBody()).contains("org.resthub.web.validation.model.InheritedClassLevelConstraintModel")
                 .contains("\"type\" : \"Size\"");
+    }
+
+    @Test
+    public void testAbstractModel() {
+        Response response = this.request("api/validation/" + AbstractModel.class.getCanonicalName()).get();
+
+        Assertions.assertThat(response.getBody()).contains("org.resthub.web.validation.model.AbstractModel")
+                .contains("\"constraints\" : { }");
+    }
+
+    @Test
+    public void testNoConstraintsModel() {
+        Response response = this.request("api/validation/" + NoConstraintsModel.class.getCanonicalName()).get();
+
+        Assertions.assertThat(response.getBody()).contains("org.resthub.web.validation.model.NoConstraintsModel")
+                .contains("\"constraints\" : { }");
     }
 }

--- a/resthub-web/resthub-web-server/src/test/java/org/resthub/web/validation/model/NoConstraintsModel.java
+++ b/resthub-web/resthub-web-server/src/test/java/org/resthub/web/validation/model/NoConstraintsModel.java
@@ -1,0 +1,36 @@
+package org.resthub.web.validation.model;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
+
+public class NoConstraintsModel {
+
+    private String field2;
+    private BModel field5;
+    private String field6;
+
+    public String getField2() {
+        return field2;
+    }
+
+    public void setField2(String field2) {
+        this.field2 = field2;
+    }
+
+    public BModel getField5() {
+        return field5;
+    }
+
+    public void setField5(BModel field5) {
+        this.field5 = field5;
+    }
+
+    public String getField6() {
+        return field6;
+    }
+
+    public void setField6(String field6) {
+        this.field6 = field6;
+    }
+}

--- a/resthub-web/resthub-web-server/src/test/java/org/resthub/web/validation/service/ValidationServiceTest.java
+++ b/resthub-web/resthub-web-server/src/test/java/org/resthub/web/validation/service/ValidationServiceTest.java
@@ -178,7 +178,8 @@ public class ValidationServiceTest extends AbstractTest {
 
         modelConstraint =
                 this.validationService.getConstraintsForClass(AbstractModel.class);
-        Assertions.assertThat(modelConstraint).isNull();
+        Assertions.assertThat(modelConstraint.getConstraints()).isNotNull();
+        Assertions.assertThat(modelConstraint.getConstraints()).isEmpty();
     }
 
     @Test
@@ -200,5 +201,26 @@ public class ValidationServiceTest extends AbstractTest {
         Assertions.assertThat(modelConstraint.getModelRef()).isNotNull().isEqualTo("org.resthub.web.validation.model.InheritedClassLevelConstraintModel");
         Assertions.assertThat(modelConstraint.getConstraints()).isNotNull().isNotEmpty().hasSize(1);
         Assertions.assertThat(modelConstraint.getConstraints()).containsKey("description");
+    }
+
+    @Test
+    public void testAbstractModel() {
+        ModelConstraint modelConstraint =
+                this.validationService.getConstraintsForClass(AbstractModel.class);
+
+        Assertions.assertThat(modelConstraint).isNotNull();
+        Assertions.assertThat(modelConstraint.getConstraints()).isNotNull();
+        Assertions.assertThat(modelConstraint.getConstraints()).isEmpty();
+    }
+
+
+    @Test
+    public void testNoConstraintsModel() {
+        ModelConstraint modelConstraint =
+                this.validationService.getConstraintsForClass(NoConstraintsModel.class);
+
+        Assertions.assertThat(modelConstraint).isNotNull();
+        Assertions.assertThat(modelConstraint.getConstraints()).isNotNull();
+        Assertions.assertThat(modelConstraint.getConstraints()).isEmpty();
     }
 }


### PR DESCRIPTION
Validation constraints requests on either abstract class or not constrained model returned empty body that should lead to jquery errors because a 200 response should hold not null body.

This PR modify theses cases returning always a body content - with an empty constraints list ({ } in JSON).

fixes #206
