### PR TITLE
fix #209 - fix JSONView serialization for PageResponse

### DIFF
--- a/resthub-web/resthub-web-common/src/main/java/org/resthub/web/PageResponse.java
+++ b/resthub-web/resthub-web-common/src/main/java/org/resthub/web/PageResponse.java
@@ -1,6 +1,7 @@
 package org.resthub.web;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonView;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Sort;
 
@@ -30,6 +31,7 @@ public class PageResponse<T extends Object> implements Page<T> {
     @Override
     @XmlElementWrapper(name = "content")
     @XmlElement(name = "content")
+    @JsonView(View.class)
     public List<T> getContent() {
         return content;
     }
@@ -39,6 +41,7 @@ public class PageResponse<T extends Object> implements Page<T> {
     }
 
     @Override
+    @JsonView(View.class)
     public int getNumber() {
         return number;
     }
@@ -48,6 +51,7 @@ public class PageResponse<T extends Object> implements Page<T> {
     }
 
     @Override
+    @JsonView(View.class)
     public int getNumberOfElements() {
         return numberOfElements;
     }
@@ -57,6 +61,7 @@ public class PageResponse<T extends Object> implements Page<T> {
     }
 
     @Override
+    @JsonView(View.class)
     public int getSize() {
         return size;
     }
@@ -66,6 +71,7 @@ public class PageResponse<T extends Object> implements Page<T> {
     }
 
     @Override
+    @JsonView(View.class)
     public long getTotalElements() {
         return totalElements;
     }
@@ -75,6 +81,7 @@ public class PageResponse<T extends Object> implements Page<T> {
     }
 
     @Override
+    @JsonView(View.class)
     public int getTotalPages() {
         return totalPages;
     }
@@ -124,5 +131,7 @@ public class PageResponse<T extends Object> implements Page<T> {
     public Sort getSort() {
         throw new UnsupportedOperationException("Not supported yet.");
     }
+
+    public interface View {};
     
 }

--- a/resthub-web/resthub-web-server/src/main/java/org/resthub/web/converter/MappingJackson2JsonHttpMessageConverter.java
+++ b/resthub-web/resthub-web-server/src/main/java/org/resthub/web/converter/MappingJackson2JsonHttpMessageConverter.java
@@ -22,10 +22,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
 import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.introspect.JacksonAnnotationIntrospector;
-import com.fasterxml.jackson.databind.module.SimpleModule;
 import org.resthub.common.view.DataView;
-import org.resthub.web.PageResponse;
-import org.springframework.data.domain.Page;
 import org.springframework.http.HttpInputMessage;
 import org.springframework.http.HttpOutputMessage;
 import org.springframework.http.MediaType;
@@ -69,9 +66,7 @@ public class MappingJackson2JsonHttpMessageConverter extends AbstractHttpMessage
     public MappingJackson2JsonHttpMessageConverter() {
         super(new MediaType("application", "json", DEFAULT_CHARSET));
         objectMapper = new ObjectMapper();
-        SimpleModule module = new SimpleModule();
-        module.addAbstractTypeMapping(Page.class, PageResponse.class);
-        objectMapper.registerModule(module);
+        objectMapper.registerModule(new ResthubPageModule());
         AnnotationIntrospector introspector = new JacksonAnnotationIntrospector();
         objectMapper.setAnnotationIntrospector(introspector);
         objectMapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
@@ -86,7 +81,7 @@ public class MappingJackson2JsonHttpMessageConverter extends AbstractHttpMessage
      * ObjectMapper} is used.
      * <p>
      * Setting a custom-configured {@code ObjectMapper} is one way to take further control of the JSON serialization
-     * process. For example, an extended {@link org.codehaus.jackson.map.SerializerFactory} can be configured that
+     * process. For example, an extended {@link com.fasterxml.jackson.databind.ser.SerializerFactory} can be configured that
      * provides custom serializers for specific types. The other option for refining the serialization process is to use
      * Jackson's provided annotations on the types to be serialized, in which case a custom-configured ObjectMapper is
      * unnecessary.
@@ -179,8 +174,8 @@ public class MappingJackson2JsonHttpMessageConverter extends AbstractHttpMessage
             }
             if (object instanceof DataView && ((DataView) object).hasView())
             {
-                ObjectWriter writter = this.objectMapper.writerWithView(((DataView) object).getView());
-                writter.writeValue(jsonGenerator, ((DataView) object).getData());
+                ObjectWriter writer = this.objectMapper.writerWithView(((DataView) object).getView());
+                writer.writeValue(jsonGenerator, ((DataView) object).getData());
             } else {
                 this.objectMapper.writeValue(jsonGenerator, object);
             }

--- a/resthub-web/resthub-web-server/src/main/java/org/resthub/web/converter/MappingJackson2XmlHttpMessageConverter.java
+++ b/resthub-web/resthub-web-server/src/main/java/org/resthub/web/converter/MappingJackson2XmlHttpMessageConverter.java
@@ -19,14 +19,12 @@ package org.resthub.web.converter;
 import com.fasterxml.jackson.core.JsonEncoding;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
 import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.introspect.JacksonAnnotationIntrospector;
-import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.dataformat.xml.JacksonXmlModule;
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import org.resthub.common.view.DataView;
-import org.resthub.web.PageResponse;
-import org.springframework.data.domain.Page;
 import org.springframework.http.HttpInputMessage;
 import org.springframework.http.HttpOutputMessage;
 import org.springframework.http.MediaType;
@@ -69,9 +67,7 @@ public class MappingJackson2XmlHttpMessageConverter extends AbstractHttpMessageC
         JacksonXmlModule xmlModule = new JacksonXmlModule();
         xmlModule.setDefaultUseWrapper(false);
         objectMapper = new XmlMapper(xmlModule);
-        SimpleModule module = new SimpleModule();
-        module.addAbstractTypeMapping(Page.class, PageResponse.class);
-        objectMapper.registerModule(module);
+        objectMapper.registerModule(new ResthubPageModule());
         AnnotationIntrospector introspector = new JacksonAnnotationIntrospector();
         objectMapper.setAnnotationIntrospector(introspector);
         objectMapper.configure(MapperFeature.DEFAULT_VIEW_INCLUSION, false);
@@ -82,7 +78,7 @@ public class MappingJackson2XmlHttpMessageConverter extends AbstractHttpMessageC
      * ObjectMapper} is used.
      * <p>
      * Setting a custom-configured {@code ObjectMapper} is one way to take further control of the JSON serialization
-     * process. For example, an extended {@link org.codehaus.jackson.map.SerializerFactory} can be configured that
+     * process. For example, an extended {@link com.fasterxml.jackson.databind.ser.SerializerFactory} can be configured that
      * provides custom serializers for specific types. The other option for refining the serialization process is to use
      * Jackson's provided annotations on the types to be serialized, in which case a custom-configured ObjectMapper is
      * unnecessary.
@@ -161,8 +157,8 @@ public class MappingJackson2XmlHttpMessageConverter extends AbstractHttpMessageC
         try {
             if (object instanceof DataView && ((DataView) object).hasView())
             {
-                ObjectWriter writter = this.objectMapper.writerWithView(((DataView) object).getView());
-                writter.writeValue(jsonGenerator, ((DataView) object).getData());
+                ObjectWriter writer = this.objectMapper.writerWithView(((DataView) object).getView());
+                writer.writeValue(jsonGenerator, ((DataView) object).getData());
             } else {
                 this.objectMapper.writeValue(jsonGenerator, object);
             }

--- a/resthub-web/resthub-web-server/src/main/java/org/resthub/web/converter/ResthubPageModule.java
+++ b/resthub-web/resthub-web-server/src/main/java/org/resthub/web/converter/ResthubPageModule.java
@@ -1,0 +1,44 @@
+package org.resthub.web.converter;
+
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import org.resthub.web.PageResponse;
+import org.springframework.data.domain.Page;
+
+
+/*
+ * Copyright 2002-2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Jackson module.
+ * Handles Spring-data's Page/PageImpl to RESThub's PageResponse mapping; in two steps:
+ * <ul>
+ *   <li>use PageResponse as a concrete type for serializing Page interface</li>
+ *   <li>use PageResponse's annotations for serialization, using mixinannotations</li>
+ * </ul>
+ *
+ */
+public class ResthubPageModule extends SimpleModule {
+
+    public ResthubPageModule() {
+        super("ResthubPageModule");
+    }
+
+    @Override
+    public void setupModule(SetupContext context) {
+        context.setMixInAnnotations(Page.class, PageResponse.class);
+        this.addAbstractTypeMapping(Page.class, PageResponse.class);
+    }
+}

--- a/resthub-web/resthub-web-server/src/test/java/org/resthub/web/controller/BookController.java
+++ b/resthub-web/resthub-web-server/src/test/java/org/resthub/web/controller/BookController.java
@@ -2,9 +2,12 @@ package org.resthub.web.controller;
 
 import org.resthub.common.view.ResponseView;
 import org.resthub.web.model.Book;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 
 import java.util.ArrayList;
@@ -26,11 +29,19 @@ public class BookController {
     {
         return data;
     }
-    @RequestMapping("summaries")
+    @RequestMapping(value= "summaries", params="page=no")
     @ResponseView(Book.SummaryView.class)
     public @ResponseBody List<Book> getBookSummaries()
     {
         return data;
+    }
+    @RequestMapping("summaries")
+    @ResponseView(Book.SummaryView.class)
+    public @ResponseBody Page<Book> getBookSummariesPaginated(@RequestParam(value = "page", required = true, defaultValue = "1") Integer page)
+    {
+        PageImpl<Book> books= new PageImpl<Book>(data);
+
+        return books;
     }
     @RequestMapping("{id}/summary")
     @ResponseView(Book.SummaryView.class)

--- a/resthub-web/resthub-web-server/src/test/java/org/resthub/web/model/Book.java
+++ b/resthub-web/resthub-web-server/src/test/java/org/resthub/web/model/Book.java
@@ -1,6 +1,7 @@
 package org.resthub.web.model;
 
 import com.fasterxml.jackson.annotation.JsonView;
+import org.resthub.web.PageResponse;
 
 public class Book {
 
@@ -82,5 +83,5 @@ public class Book {
     }
 
     // Sample View
-    public static interface SummaryView {}
+    public static interface SummaryView extends PageResponse.View {}
 }

--- a/resthub-web/resthub-web-server/src/test/java/org/resthub/web/test/ResponseViewTest.java
+++ b/resthub-web/resthub-web-server/src/test/java/org/resthub/web/test/ResponseViewTest.java
@@ -3,6 +3,7 @@ package org.resthub.web.test;
 import com.fasterxml.jackson.core.type.TypeReference;
 import org.fest.assertions.api.Assertions;
 import org.resthub.test.AbstractWebTest;
+import org.resthub.web.PageResponse;
 import org.resthub.web.model.Book;
 import org.testng.annotations.Test;
 
@@ -26,12 +27,22 @@ public class ResponseViewTest extends AbstractWebTest {
 
     @Test
     public void testSummaryListJson() {
-        List<Book> books = this.request("book/summaries").jsonGet().resource(new TypeReference<List<Book>>() {
+        List<Book> books = this.request("book/summaries").setQueryParameter("page","no").jsonGet().resource(new TypeReference<List<Book>>() {
         });
         Assertions.assertThat(books).isNotNull();
         Assertions.assertThat(books.size()).isEqualTo(2);
         Assertions.assertThat(books).contains(new Book(null,"Joshua Bloch",null,1));
         Assertions.assertThat(books).contains(new Book(null,"Stephanie Myers",null,2));
+    }
+
+    @Test
+    public void testSummaryPageableListJson() {
+        PageResponse<Book> books = this.request("book/summaries").setQueryParameter("page","1").jsonGet().resource(new TypeReference<PageResponse<Book>>() {
+        });
+        Assertions.assertThat(books).isNotNull();
+        Assertions.assertThat(books.getContent().size()).isEqualTo(2);
+        Assertions.assertThat(books.getContent()).contains(new Book(null,"Joshua Bloch",null,1));
+        Assertions.assertThat(books.getContent()).contains(new Book(null,"Stephanie Myers",null,2));
     }
 
     @Test


### PR DESCRIPTION
Found a fix for issue #209

Adding @JsonView annotations in PageResponse was not enough, because the ObjectWriter wouldn't pick up its annotations. I had to set a MixIn annotation to do that.
Let me know if the changes made in the test controller aren't great.
