### PR TITLE
Print the complete exception stack when captured by the LoggingHandler

### DIFF
--- a/resthub-web/resthub-web-server/src/main/java/org/resthub/web/LoggingHandlerExceptionResolver.java
+++ b/resthub-web/resthub-web-server/src/main/java/org/resthub/web/LoggingHandlerExceptionResolver.java
@@ -26,7 +26,7 @@ public class LoggingHandlerExceptionResolver implements HandlerExceptionResolver
 
     @Override
     public ModelAndView resolveException(HttpServletRequest request, HttpServletResponse response, Object handler, Exception e) {
-        logger.warn("Exception catched by Spring MVC: " + e);
+        logger.warn("Exception catched by Spring MVC: ", e);
         return null; // trigger other HandlerExceptionResolver's
     }
     


### PR DESCRIPTION
When an exception is thrown (by an Assert.notNull() for instance), the LoggingHandlerExceptionResolver catches it and only logs the message of the exception. So one loses the exception location. 
I just replace the argument to log the complete stack
